### PR TITLE
[PATCH] expanded Tensor<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PMT Objects represent a serializable container of data that can be passed across
 
 - meson
 - ninja
-- C++20
+- C++23
 
 ## Installation
 

--- a/bench/bm_pmt_serialize_uvec.cpp
+++ b/bench/bm_pmt_serialize_uvec.cpp
@@ -26,7 +26,7 @@ using namespace pmtv;
 bool run_test(const int32_t times, const std::vector<int32_t>& data)
 {
     bool valid = true;
-    Tensor<int32_t> tdata(Tensor1d(), data);
+    Tensor<int32_t> tdata(pmtv::data_from, data);
 
     std::stringbuf sb; // fake channel
     for (int i = 0; i < times; i++) {

--- a/include/pmtv/type_helpers.hpp
+++ b/include/pmtv/type_helpers.hpp
@@ -26,13 +26,94 @@ struct tensor_data_tag {};
 inline constexpr tensor_extents_tag extents_from{};
 inline constexpr tensor_data_tag data_from{};
 
-template <class T_>
+/**
+ * @class Tensor
+ * @brief A multi-dimensional array container with a flexible compile-time and runtime multi-dimensional extent data storage support
+ *
+ * @tparam ElementType The type of elements stored (bool is stored as uint8_t internally)
+ * @tparam Ex Variable number of extents (use std::dynamic_extent for runtime dimensions)
+
+ * ##BasicUsage Basic Usage Examples:
+ * ### fully run-time dynamic Tensor<T>
+ * @code
+ * Tensor<double> matrix({3, 4}, data);
+ * matrix[2, 3] = 42.0;
+ * matrix.reshape({2, 6});  // same data, new shape
+ * @endcode
+ *
+ * ### static rank, dynamic extents Tensor<T>
+ * @code
+ * Tensor<float, std::dynamic_extent, std::dynamic_extent> img({640, 480});
+ * img.resize({1920, 1080});  // can change dimensions
+ * @endcode
+ *
+ * ### fully static Tensor<T>
+ * @code
+ * // all compile-time, zero overhead
+ * constexpr Tensor<int, 2, 3> mat{{1, 2, 3}, {4, 5, 6}};
+ * constexpr auto elem = mat[1, 2];  // compile-time access
+ * static_assert(mat.size() == 6);
+ * @endcode
+ *
+ * ## std::vector compatibility
+ * @code
+ * std::vector<int> vec{1, 2, 3, 4, 5};
+ * Tensor<int> tensor(vec);           // construct from vector
+ * tensor = vec;                       // assign from vector
+ * auto v2 = static_cast<std::vector<int>>(tensor);  // convert back
+ * @endcode
+ *
+ * ## tagged constructors for disambiguation
+ * @code
+ * std::vector<size_t> values{10, 20, 30};
+ * Tensor<size_t> t1(extents_from, values);  // shape: 10×20×30
+ * Tensor<size_t> t2(data_from, values);     // data: {10,20,30}
+ * @endcode
+ *
+ * ## custom polymorphic memory resources support (PMR=
+ * @code
+ * std::pmr::monotonic_buffer_resource arena(buffer, size);
+ * Tensor<double> tensor({1000, 1000}, &arena);  // use arena allocator
+ * @endcode
+ *
+ * ## type and layout conversion
+ * @code
+ * Tensor<int, 3, 3> static_tensor{...};
+ * Tensor<double> dynamic_tensor(static_tensor);  // int→double, static→dynamic
+ * @endcode
+ *
+ * ## mdspan/mdarray compatibility
+ * @code
+ * auto view = tensor.to_mdspan();  // get mdspan view
+ * view(i, j) = value;               // mdspan-style access
+ * tensor.stride(0);                 // get stride for dimension
+ * @endcode
+ *
+ * @note row-major (C/C++-style) ordering is used exclusively
+ * @note bool tensors store data as uint8_t to avoid vector<bool> issues
+ * @note static tensors have compile-time size guarantees and zero overhead
+ * @note inspired by @see https://wg21.link/P1684 (mdarray proposal)
+ */
+template <class ElementType, std::size_t... Ex>
 struct Tensor {
-    using T = std::conditional_t<std::same_as<T_, bool>, uint8_t, T_>;
+    using T = std::conditional_t<std::same_as<ElementType, bool>, uint8_t, ElementType>;
     using value_type = T;
 
-    std::pmr::vector<std::size_t> _extents;
-    std::pmr::vector<T> _data;
+    static constexpr bool        _all_static = sizeof...(Ex) > 0UZ && ((Ex != std::dynamic_extent) && ...);
+    static constexpr std::size_t _size_ct    = _all_static ? (Ex * ... * 1UZ) : 0UZ;
+    struct no_extents_t {}; // zero-sized tag for a fully static/constexpr case
+    using extents_store_t = std::conditional_t<_all_static, no_extents_t,
+            std::conditional_t<(sizeof...(Ex) > 0UZ), std::array<std::size_t, sizeof...(Ex)>,
+                                                      std::pmr::vector<std::size_t>>>;
+    using container_type = std::conditional_t<_all_static, std::array<T, _size_ct>, std::pmr::vector<T>>;
+    using pointer = container_type::pointer;
+    using const_pointer = container_type::const_pointer;
+    using reference = container_type::reference;
+    using const_reference = container_type::const_reference;
+
+
+    [[no_unique_address]] extents_store_t _extents{};
+    container_type                        _data{};
 
     static constexpr std::size_t product(std::span<const std::size_t> ex) {
         std::size_t n{1UZ};
@@ -49,150 +130,365 @@ struct Tensor {
 
     constexpr void bounds_check(std::span<const std::size_t> indices) const {
         if (indices.size() != rank())
+        {
             throw std::out_of_range("Tensor::at: incorrect number of indices");
-        for (std::size_t d = 0; d < rank(); ++d)
-            if (indices[d] >= _extents[d])
+        }
+        for (std::size_t d = 0; d < rank(); ++d) {
+            if (indices[d] >= _extents[d]) {
                 throw std::out_of_range("Tensor::at: index out of bounds");
+            }
+        }
     }
 
     // row-major fold from a span
     [[nodiscard]] constexpr std::size_t index_of(std::span<const std::size_t> idx) const noexcept {
         std::size_t lin = 0UZ;
-        for (std::size_t d = 0; d < idx.size(); ++d) {
-            lin = lin * _extents[d] + idx[d];
+        for (std::size_t d = 0UZ; d < idx.size(); ++d) {
+            lin = lin * extent(d) + idx[d];
         }
         return lin;
     }
 
-    // row-major fold (variadic)
     template <std::integral... Indices>
     [[nodiscard]] constexpr std::size_t index_of(Indices... indices) const noexcept {
-        std::array<std::size_t, sizeof...(Indices)> a{ static_cast<std::size_t>(indices)... };
-        assert(a.size() == rank());
-        return index_of(std::span<const std::size_t>(a));
-    }
-
-    Tensor(const Tensor& other, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
-    : _extents(other._extents.begin(), other._extents.end(), mr),
-      _data(other._data.begin(), other._data.end(), mr) {}
-
-    Tensor(Tensor&& other) noexcept = default;
-
-    Tensor& operator=(const Tensor& other) {
-        if (this != &other) {
-            _extents = other._extents;
-            _data = other._data;
+        if constexpr (_all_static) {
+            static_assert(sizeof...(Indices) == sizeof...(Ex), "Tensor::index_of: incorrect number of indices");
+            constexpr std::size_t E[]{Ex...};
+            std::size_t idx_array[]{static_cast<std::size_t>(indices)...};
+            std::size_t lin = 0UZ;
+            for (std::size_t d = 0UZ; d < sizeof...(Ex); ++d) {
+                lin = lin * E[d] + idx_array[d];
+            }
+            return lin;
+        } else {
+            std::array<std::size_t, sizeof...(Indices)> a{static_cast<std::size_t>(indices)...};
+            return index_of(std::span<const std::size_t>(a));
         }
-        return *this;
     }
-    Tensor& operator=(Tensor&& other) noexcept = default;
 
-    explicit Tensor(std::pmr::memory_resource* mr = std::pmr::get_default_resource())
-        : _extents(mr), _data(mr) {}
+    constexpr Tensor() requires (_all_static) = default;
+
+    Tensor(const Tensor& other, std::pmr::memory_resource* mr = std::pmr::get_default_resource()) requires (!_all_static)
+        : _extents(mr), _data(other._data.begin(), other._data.end(), mr) {
+        if constexpr (std::is_same_v<extents_store_t, std::pmr::vector<std::size_t>>) {
+            _extents.assign(other._extents.begin(), other._extents.end());
+        } else {
+            _extents = other._extents;
+        }
+    }
+
+    Tensor(const Tensor& other) requires (_all_static) = default;
+    Tensor(Tensor&& other) noexcept = default;
+    explicit Tensor(std::pmr::memory_resource* mr = std::pmr::get_default_resource()) noexcept requires (!_all_static) : _extents(mr), _data(mr) {}
 
     template <std::ranges::range Extents>
-        requires std::same_as<std::ranges::range_value_t<Extents>, std::size_t>
-    explicit Tensor(const Extents& extents,
-           std::pmr::memory_resource* mr = std::pmr::get_default_resource())
-        : _extents(extents.begin(), extents.end(), mr),
-          _data(checked_size(_extents), mr) {}
+    requires (std::same_as<std::ranges::range_value_t<Extents>, std::size_t> && !std::is_same_v<std::remove_cvref_t<Extents>, std::initializer_list<std::size_t>>)
+    explicit Tensor(const Extents& extents, std::pmr::memory_resource* mr = std::pmr::get_default_resource()) requires (!_all_static)
+        : _extents(mr), _data(mr) {
+        if constexpr (std::is_same_v<extents_store_t, std::pmr::vector<std::size_t>>) {
+            _extents.assign(std::ranges::begin(extents), std::ranges::end(extents));
+        } else {
+            std::size_t i = 0;
+            for (auto e : extents) {
+                _extents[i++] = e;
+            }
+        }
+        _data.resize(checked_size(std::span<const std::size_t>(_extents.data(), _extents.size())));
+    }
 
-    Tensor(std::initializer_list<std::size_t> extents,
-           std::pmr::memory_resource* mr = std::pmr::get_default_resource())
-        : _extents(extents.begin(), extents.end(), mr),
-          _data(checked_size(_extents), mr) {}
+    Tensor(std::initializer_list<std::size_t> extents, std::pmr::memory_resource* mr = std::pmr::get_default_resource()) requires (!_all_static)
+        : _data(mr) {  // _extents{} default-initializes (works for both std::array and pmr::vector)
+        if constexpr (std::is_same_v<extents_store_t, std::pmr::vector<std::size_t>>) { // fully dynamic rank and extents
+            _extents = std::pmr::vector<std::size_t>(extents.begin(), extents.end(), mr);
+        } else { // static rank, dynamic extents (using std::array)
+            if (extents.size() != sizeof...(Ex)) {
+                throw std::runtime_error("Wrong number of extents for static rank tensor");
+            }
+            std::copy(extents.begin(), extents.end(), _extents.begin());
+        }
+        _data.resize(checked_size(std::span<const std::size_t>(_extents.data(), _extents.size())));
+    }
+
+    template<typename U>
+    requires (!_all_static && sizeof...(Ex) == 1 && ((Ex == std::dynamic_extent) && ...) && std::convertible_to<U, T>)
+    Tensor(std::initializer_list<U> values, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+        : _extents{values.size()}, _data(values.begin(), values.end(), mr) {}
 
     template <std::ranges::range Extents, std::ranges::range Data>
-    requires (std::same_as<std::ranges::range_value_t<Extents>, std::size_t>
-        && std::same_as<std::ranges::range_value_t<Data>, T>)
-    Tensor(const Extents& extents, const Data& data, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
-        : _extents(extents.begin(), extents.end(), mr), _data(data.begin(), data.end(), mr) {
-        if (_data.size() != checked_size(_extents)) {
+    requires (std::same_as<std::ranges::range_value_t<Extents>, std::size_t> && std::same_as<std::ranges::range_value_t<Data>, T>)
+    Tensor(const Extents& extents, const Data& data, std::pmr::memory_resource* mr = std::pmr::get_default_resource()) requires (!_all_static)
+        : _extents(mr), _data(std::ranges::begin(data), std::ranges::end(data), mr) {
+        if constexpr (std::is_same_v<extents_store_t, std::pmr::vector<std::size_t>>) {
+            _extents.assign(std::ranges::begin(extents), std::ranges::end(extents));
+        } else {
+            std::size_t i = 0UZ;
+            for (auto e : extents) {
+                _extents[i++] = e;
+            }
+        }
+        if (_data.size() != checked_size(std::span<const std::size_t>(_extents.data(), _extents.size()))) {
             throw std::runtime_error("Tensor: data size doesn't match extents product.");
         }
     }
 
     template<std::ranges::range Range>
     requires std::same_as<std::ranges::range_value_t<Range>, std::size_t>
-    Tensor(tensor_extents_tag, const Range& extents, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
-    : _extents(extents.begin(), extents.end(), mr), _data(checked_size(_extents), mr) {}
+    Tensor(tensor_extents_tag, const Range& extents, std::pmr::memory_resource* mr = std::pmr::get_default_resource()) requires (!_all_static)
+        : _extents(mr), _data(mr) {
+        if constexpr (std::is_same_v<extents_store_t, std::pmr::vector<std::size_t>>) {
+            _extents.assign(std::ranges::begin(extents), std::ranges::end(extents));
+        } else {
+            std::size_t i = 0UZ;
+            for (auto e : extents) {
+                _extents[i++] = e;
+            }
+        }
+        _data.resize(checked_size(std::span<const std::size_t>(_extents.data(), _extents.size())));
+    }
 
     template<std::ranges::range Range>
     requires std::same_as<std::ranges::range_value_t<Range>, T>
-    Tensor(tensor_data_tag, const Range& data, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
-        : _extents({std::size_t(std::ranges::size(data))}, mr), _data(data.begin(), data.end(), mr) {}
+    Tensor(tensor_data_tag, const Range& data, std::pmr::memory_resource* mr = std::pmr::get_default_resource()) requires (!_all_static)
+        : _extents(mr), _data(std::ranges::begin(data), std::ranges::end(data), mr) { _extents.push_back(std::ranges::size(data)); }
 
-    Tensor(std::size_t count, const T& value, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
-        : _extents({count}, mr), _data(count, value, mr) {}
+    Tensor(std::size_t count, const T& value, std::pmr::memory_resource* mr = std::pmr::get_default_resource()) requires (!_all_static)
+    : _extents(mr), _data(count, value, mr) { _extents.push_back(count); }
 
     template<std::input_iterator InputIt>
-    Tensor(InputIt first, InputIt last, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+    Tensor(InputIt first, InputIt last, std::pmr::memory_resource* mr = std::pmr::get_default_resource()) requires (!_all_static)
         : _extents(mr), _data(first, last, mr) { _extents.push_back(_data.size()); }
-
-    // Usage examples:
-    /**
-    std::vector<std::size_t> v{10, 20, 30};
-    Tensor<std::size_t> t1(extents_from, v);  // Clear: extents {10,20,30}
-    Tensor<std::size_t> t2(data_from, v);     // Clear: 1D data {10,20,30}
-    */
-
-
-    /**===== std::vector/std::pmr::vector COMPATIBILITY ===== */
 
     template <std::ranges::range Data>
     requires std::same_as<std::ranges::range_value_t<Data>, T>
-    Tensor(std::initializer_list<std::size_t> extents, const Data& data,
-        std::pmr::memory_resource* mr = std::pmr::get_default_resource())
-    : _extents(extents.begin(), extents.end(), mr), _data(data.begin(), data.end(), mr) {
-        if (_data.size() != checked_size(_extents)) {
+    Tensor(std::initializer_list<std::size_t> extents, const Data& data, std::pmr::memory_resource* mr = std::pmr::get_default_resource()) requires (!_all_static)
+        : _extents(mr), _data(std::ranges::begin(data), std::ranges::end(data), mr) {
+        if constexpr (std::is_same_v<extents_store_t, std::pmr::vector<std::size_t>>) {
+            _extents.assign(extents.begin(), extents.end());
+        } else {
+            std::copy(extents.begin(), extents.end(), _extents.begin());
+        }
+        if (_data.size() != checked_size(std::span<const std::size_t>(_extents.data(), _extents.size()))) {
             throw std::runtime_error("Tensor: data size doesn't match extents product.");
         }
     }
 
     template<class U, class Allocator>
     requires std::same_as<U, T>
-    explicit Tensor(const std::vector<U, Allocator>& vec, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
-        : _extents({vec.size()}, mr), _data(vec.begin(), vec.end(), mr) {}
+    explicit Tensor(const std::vector<U, Allocator>& vec, std::pmr::memory_resource* mr = std::pmr::get_default_resource()) requires (!_all_static)
+        : _extents(mr), _data(vec.begin(), vec.end(), mr) { _extents.push_back(vec.size()); }
 
     template<class U>
     requires std::same_as<U, T>
-    explicit Tensor(const std::pmr::vector<U>& vec, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
-        : _extents({vec.size()}, mr), _data(vec.begin(), vec.end(), mr) {}
+    explicit Tensor(std::pmr::vector<U>&& vec, std::pmr::memory_resource* mr = std::pmr::get_default_resource()) requires (!_all_static)
+        : _extents(mr), _data(mr) {
+            std::size_t sz = vec.size();  // Get size BEFORE moving
 
-    template<class U>
-    requires std::same_as<U, T>
-    explicit Tensor(std::pmr::vector<U>&& vec, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
-        : _extents({vec.size()}, mr), _data(std::move(vec)) {
-        if (_data.get_allocator().resource() != mr) {
-            _data = std::pmr::vector<T>(std::make_move_iterator(_data.begin()), std::make_move_iterator(_data.end()), mr);
+            if (vec.get_allocator().resource() == mr) { // same allocator - can actually move
+                _data = std::move(vec);
+            } else { // different allocators - copy data but use move iterators for efficiency
+                _data.reserve(sz);
+                _data.assign(std::make_move_iterator(vec.begin()), std::make_move_iterator(vec.end()));
+            }
+        _extents.push_back(sz); // CRITICAL: need to set extents AFTER moving data
+    }
+
+    // flat initializer list for static tensors
+    template<typename U>
+    requires (_all_static && std::convertible_to<U, T>)
+    constexpr Tensor(std::initializer_list<U> values) {
+        if (values.size() != _size_ct) {
+            throw std::runtime_error("Initializer list size doesn't match tensor size");
         }
+        std::copy(values.begin(), values.end(), _data.begin());
+    }
+
+    // 2D nested initializer list
+    template<typename U>
+    requires (_all_static && sizeof...(Ex) == 2 && std::convertible_to<U, T>)
+    constexpr Tensor(std::initializer_list<std::initializer_list<U>> values) : _data{} {
+        constexpr std::array<std::size_t, 2UZ> dims{Ex...};
+        if (values.size() != dims[0UZ]) {
+            throw std::runtime_error("Wrong number of rows");
+        }
+
+        std::size_t idx = 0UZ;
+        for (auto row : values) {
+            if (row.size() != dims[1UZ]) {
+                throw std::runtime_error("Wrong number of columns");
+            }
+            for (auto val : row) {
+                _data[idx++] = val;
+            }
+        }
+    }
+
+    // 3D nested initializer list
+    template<typename U>
+    requires (_all_static && sizeof...(Ex) == 3 && std::convertible_to<U, T>)
+    constexpr Tensor(std::initializer_list<std::initializer_list<std::initializer_list<U>>> values) : _data{} {
+        constexpr std::array<std::size_t, 3> dims{Ex...};
+        if (values.size() != dims[0]) {
+            throw std::runtime_error("Wrong dimension 0 size");
+        }
+
+        std::size_t idx = 0;
+        for (auto plane : values) {
+            if (plane.size() != dims[1]) {
+                throw std::runtime_error("Wrong dimension 1 size");
+            }
+            for (auto row : plane) {
+                if (row.size() != dims[2]) {
+                    throw std::runtime_error("Wrong dimension 2 size");
+                }
+                for (auto val : row) {
+                    _data[idx++] = val;
+                }
+            }
+        }
+    }
+
+    // conversion constructors from static, semi-static, and fully dynamic Tensor<T, ...> types
+    template<typename OtherT, std::size_t... OtherEx>
+    requires (std::convertible_to<OtherT, T> && (sizeof...(Ex) == 0 || sizeof...(OtherEx) == 0 || sizeof...(Ex) == sizeof...(OtherEx)))
+    explicit Tensor(const Tensor<OtherT, OtherEx...>& other, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+        : _extents([mr]() {
+            if constexpr (_all_static) {
+                return extents_store_t{}; // no_extents_t - no allocator needed
+            } else if constexpr (std::is_same_v<extents_store_t, std::pmr::vector<std::size_t>>) {
+                return extents_store_t(mr); // PMR vector with correct resource
+            } else {
+                return extents_store_t{}; // std::array - no allocator needed
+            }
+        }()),
+        _data([mr]() {
+            if constexpr (_all_static) {
+                return container_type{}; // std::array - no allocator needed
+            } else {
+                return container_type(mr); // PMR vector with correct resource
+            }
+        }()) {
+            std::vector<std::size_t> src_dims;
+            if constexpr (Tensor<OtherT, OtherEx...>::_all_static) {
+                constexpr std::array<std::size_t, sizeof...(OtherEx)> static_dims{OtherEx...};
+                src_dims.assign(static_dims.begin(), static_dims.end());
+            } else {
+                src_dims.assign(other._extents.begin(), other._extents.end());
+            }
+
+        if constexpr (_all_static) { // static target - validate dimensions and copy data
+            constexpr std::array<std::size_t, sizeof...(Ex)> target_dims{Ex...};
+            if (src_dims.size() != sizeof...(Ex)) {
+                throw std::runtime_error("Rank mismatch in tensor conversion");
+            }
+            for (std::size_t i = 0; i < sizeof...(Ex); ++i) {
+                if (src_dims[i] != target_dims[i]) {
+                    throw std::runtime_error("Dimension mismatch in tensor conversion");
+                }
+            }
+            std::copy(other.begin(), other.end(), _data.begin());
+        } else { // dynamic target - _extents and _data already have correct allocator from initializer list
+            if constexpr (sizeof...(Ex) > 0) {
+                // semi-static: fixed rank, dynamic extents
+                if (src_dims.size() != sizeof...(Ex)) {
+                    throw std::runtime_error("Rank mismatch in tensor conversion");
+                }
+                std::copy(src_dims.begin(), src_dims.end(), _extents.begin());
+            } else { // fully dynamic: assign dimensions (allocator already correct)
+                _extents.assign(src_dims.begin(), src_dims.end());
+            }
+
+            // copy data (allocator already correct from member init)
+            _data.assign(other.begin(), other.end());
+        }
+    }
+
+    [[nodiscard]] static constexpr Tensor identity() requires (_all_static) {
+        constexpr std::size_t N = (Ex * ...);
+        Tensor identity = T(0);
+        for (std::size_t i = 0UZ; i < N; ++i) {
+            identity[i, i] = T{1};
+        }
+        return identity;
+    }
+
+    Tensor& operator=(Tensor&& other) noexcept = default;
+
+    // Replace the existing template assignment operator with this simplified version
+    template<typename OtherT, std::size_t... OtherEx>
+    Tensor& operator=(const Tensor<OtherT, OtherEx...>& other) {
+        // Handle self-assignment for identical types
+        if constexpr (std::is_same_v<Tensor, Tensor<OtherT, OtherEx...>>) {
+            if (this == reinterpret_cast<const Tensor*>(&other)) {
+                return *this;
+            }
+        }
+
+        // Create temporary using the conversion constructor and swap with it
+        if constexpr (_all_static) {
+            // Target is static - use default constructor (no allocator needed)
+            Tensor temp(other);
+            swap(temp);
+        } else {
+            // Target is dynamic - preserve this tensor's allocator
+            Tensor temp(other, _data.get_allocator().resource());
+            swap(temp);
+        }
+
+        return *this;
     }
 
     template<class U, class Allocator>
     requires std::same_as<U, T>
     Tensor& operator=(const std::vector<U, Allocator>& vec) {
-        _extents = {vec.size()};
-        _data.assign(vec.begin(), vec.end());
+        if constexpr (!_all_static) {
+            _extents.clear();
+            _extents.push_back(vec.size());
+            _data.assign(vec.begin(), vec.end());
+        }
         return *this;
     }
 
     template<class U>
     requires std::same_as<U, T>
     Tensor& operator=(const std::pmr::vector<U>& vec) {
-        _extents = {vec.size()};
-        _data.assign(vec.begin(), vec.end());
+        if constexpr (!_all_static) {
+            _extents.clear();
+            _extents.push_back(vec.size());
+            _data.assign(vec.begin(), vec.end());
+        }
+        return *this;
+    }
+
+    Tensor& operator=(const Tensor& other) {
+        if (this != &other) {
+            if constexpr (!_all_static) { // dynamic tensors, need to handle PMR resources properly
+                if (_data.get_allocator().resource() == other._data.get_allocator().resource()) {
+                    _extents = other._extents;
+                    _data = other._data;
+                } else { // different memory resources - need to copy
+                    _data.assign(other._data.begin(), other._data.end());
+                    if constexpr (std::is_same_v<extents_store_t, std::pmr::vector<std::size_t>>) {
+                        _extents.assign(other._extents.begin(), other._extents.end());
+                    } else {
+                        _extents = other._extents;
+                    }
+                }
+            } else { // static tensors, just copy the data
+                _data = other._data;
+            }
+        }
         return *this;
     }
 
     explicit constexpr operator std::vector<T>() const {
-        if (rank() != 1) {
+        if (rank() != 1UZ) {
             throw std::runtime_error("Can only convert 1D tensors to std::vector");
         }
         return std::vector<T>(_data.begin(), _data.end());
     }
 
     explicit constexpr operator std::pmr::vector<T>() const {
-        if (rank() != 1) {
+        if (rank() != 1UZ) {
             throw std::runtime_error("Can only convert 1D tensors to std::pmr::vector");
         }
         return std::pmr::vector<T>(_data.begin(), _data.end(), _data.get_allocator().resource());
@@ -202,13 +498,13 @@ struct Tensor {
     [[nodiscard]] std::size_t capacity() const noexcept { return _data.capacity(); }
     void reserve(std::size_t new_cap) { _data.reserve(new_cap); }
     void shrink_to_fit() { _data.shrink_to_fit();  }
-    void clear() noexcept {
+    void clear() noexcept requires (!_all_static) {
         _extents.clear();
         _data.clear();
     }
 
     // Resize specific dimension
-    void resize_dim(std::size_t dim, std::size_t new_extent) {
+    void resize_dim(std::size_t dim, std::size_t new_extent) requires (!_all_static) {
         if (dim >= rank()) {
             throw std::out_of_range("resize_dim: dimension out of range");
         }
@@ -241,22 +537,22 @@ struct Tensor {
         _data.assign(new_size, value);
     }
 
-    [[nodiscard]] T& front() {
+    [[nodiscard]] reference front() {
         if (empty()) throw std::runtime_error("front() on empty tensor");
         return _data.front();
     }
 
-    [[nodiscard]] const T& front() const {
+    [[nodiscard]] const_reference front() const {
         if (empty()) throw std::runtime_error("front() on empty tensor");
         return _data.front();
     }
 
-    [[nodiscard]] T& back() {
+    [[nodiscard]] reference back() {
         if (empty()) throw std::runtime_error("back() on empty tensor");
         return _data.back();
     }
 
-    [[nodiscard]] const T& back() const {
+    [[nodiscard]] const_reference back() const {
         if (empty()) throw std::runtime_error("back() on empty tensor");
         return _data.back();
     }
@@ -331,28 +627,78 @@ struct Tensor {
     }
 
     void swap(Tensor& other) noexcept {
-        _extents.swap(other._extents);
-        _data.swap(other._data);
+        if constexpr (_all_static) {
+            _data.swap(other._data);
+        } else {
+            _extents.swap(other._extents);
+            _data.swap(other._data);
+        }
     }
 
     // --- basic props ---
-    [[nodiscard]] constexpr std::size_t rank()   const noexcept { return _extents.size(); }
-    [[nodiscard]] constexpr std::size_t size()   const noexcept { return _data.size(); }
+    [[nodiscard]] constexpr std::size_t rank() const noexcept requires (!_all_static && sizeof...(Ex) == 0UZ) { return _extents.size(); }
+    [[nodiscard]] static consteval std::size_t rank() requires (_all_static || sizeof...(Ex) > 0UZ) { return sizeof...(Ex); }
+    [[nodiscard]] constexpr std::size_t size() const noexcept requires (!_all_static) { return _data.size(); }
+    [[nodiscard]] static consteval std::size_t size() requires (_all_static) { return _size_ct; }
+    [[nodiscard]] constexpr std::size_t container_size() const noexcept { return size(); };
     [[nodiscard]] constexpr bool        empty()  const noexcept { return _data.empty(); }
-    [[nodiscard]] constexpr std::size_t extent(std::size_t d) const noexcept { return _extents[d]; }
-    [[nodiscard]] constexpr std::span<const std::size_t> extentsSpan() const noexcept { return _extents; }
+    [[nodiscard]] constexpr std::size_t extent(std::size_t d) const noexcept {
+        if constexpr (_all_static) {
+            constexpr std::size_t E[]{Ex...}; return E[d];
+        } else {
+            return _extents[d];
+        }
+    }
+    [[nodiscard]] constexpr std::span<const std::size_t> extents() const noexcept requires (!_all_static) {
+        return std::span<const std::size_t>(_extents.data(), _extents.size());
+    }
+    [[nodiscard]] std::array<std::size_t, sizeof...(Ex)> extents() const noexcept requires (_all_static) {
+        return std::array<std::size_t, sizeof...(Ex)>{Ex...};
+    }
+    [[nodiscard]] constexpr std::size_t stride(std::size_t r) const noexcept {
+        std::size_t s = 1UZ;
+        for (std::size_t i = r + 1; i < rank(); ++i) {
+            s *= extent(i);
+        }
+        return s;
+    }
+
+    [[nodiscard]] constexpr std::pmr::vector<std::size_t> strides() const {
+        std::pmr::vector<std::size_t> s;
+        s.resize(rank());
+        if (rank() == 0UZ) return s;
+        std::size_t stride = 1UZ;
+        for (std::size_t i = rank(); i-- > 0UZ;) {
+            s[i] = stride;
+            stride *= extent(i);
+        }
+        return s;
+    }
 
     // --- iterators / STL compat ---
-    [[nodiscard]] T*       data()       noexcept { return _data.data(); }
-    [[nodiscard]] const T* data() const noexcept { return _data.data(); }
-    auto begin() noexcept { return _data.begin(); }
-    auto end()   noexcept { return _data.end(); }
-    auto begin() const noexcept { return _data.begin(); }
-    auto end()   const noexcept { return _data.end(); }
-    auto cbegin() const noexcept { return _data.cbegin(); }
-    auto cend()   const noexcept { return _data.cend(); }
+    [[nodiscard]] pointer       data()       noexcept { return std::to_address(_data.begin()); }
+    [[nodiscard]] const_pointer data() const noexcept { return std::to_address(_data.cbegin()); }
+    [[nodiscard]] constexpr pointer container_data() noexcept { return std::to_address(_data.begin()); }
+    [[nodiscard]] constexpr const_pointer container_data() const noexcept { return std::to_address(_data.cbegin()); }
+    [[nodiscard]] pointer begin() noexcept { return std::to_address(_data.begin()); }
+    [[nodiscard]] pointer end()   noexcept { return std::to_address(_data.end()); }
+    [[nodiscard]] const_pointer begin() const noexcept { return std::to_address(_data.cbegin()); }
+    [[nodiscard]] const_pointer end()   const noexcept { return std::to_address(_data.cend()); }
+    [[nodiscard]] const_pointer cbegin() const noexcept { return std::to_address(_data.cbegin()); }
+    [[nodiscard]] const_pointer cend()   const noexcept { return std::to_address(_data.cend()); }
 
-    [[nodiscard]] constexpr std::span<const size_t> extents() const noexcept { return std::span(_extents); }
+    [[nodiscard]] constexpr std::span<const size_t> extents() const noexcept {
+        if constexpr (_all_static) {
+            static constexpr std::array<std::size_t, sizeof...(Ex)> e{Ex...};
+            return std::span<const std::size_t>(e);
+        } else {
+            return std::span(_extents);
+        }
+    }
+    template <std::size_t idx>
+    static consteval std::size_t extent() requires (_all_static) {
+        constexpr std::size_t E[]{Ex...}; return E[idx];
+    }
     [[nodiscard]] constexpr std::span<T> data_span() noexcept {return std::span(_data); }
     [[nodiscard]] constexpr std::span<const T> data_span() const noexcept {return std::span(_data); }
 
@@ -365,13 +711,12 @@ struct Tensor {
         assert(rank() == 1);
         return _data[idx];
     }
-    // Templated multi-bracket operator - unchecked (similar to vector '[..]' to 'at(..)'
     template <std::integral... Indices>
-    [[nodiscard]] T& operator[](Indices... idx)       noexcept { return _data[index_of(idx...)]; }
+    constexpr T& operator[](Indices... idx)       noexcept { return _data[index_of(idx...)]; }
     template <std::integral... Indices>
     constexpr const T& operator[](Indices... idx) const noexcept { return _data[index_of(idx...)]; }
 
-    // Checked access (throws std::out_of_range)
+    // checked access (throws std::out_of_range)
     [[nodiscard]] T& at(std::span<const std::size_t> indices) {
         bounds_check(indices);
         return _data[index_of(indices)];
@@ -400,8 +745,13 @@ struct Tensor {
         return _data <=> other._data;
     }
 
-    constexpr bool operator==(const Tensor<T>& other) const noexcept {
-        return _extents == other._extents && _data == other._data;
+    template<typename OtherT, std::size_t... OtherEx>
+    constexpr bool operator==(const Tensor<OtherT, OtherEx...>& other) const noexcept {
+        if constexpr (std::is_same_v<ElementType, OtherT> && sizeof...(Ex) == sizeof...(OtherEx) && ((Ex == OtherEx) && ...)) {
+            return _data == other._data; // same type and dimensions - compare data only
+        } else { // different types or dimensions - can't be equal
+            return false;
+        }
     }
 
     template<class U, class Allocator>
@@ -428,41 +778,34 @@ struct Tensor {
         return tensor == vec;
     }
 
-    void fill(const T& v) { std::ranges::fill(_data, v); }
-
-
-
-    void reshape(std::initializer_list<std::size_t> newExtents) { reshape(std::span(newExtents)); }
-
-    template<std::ranges::range Range>
-    requires std::same_as<std::ranges::range_value_t<Range>, std::size_t>
-    void reshape(const Range& newExtents) { // reshape without moving data; preserves total size
-        const std::size_t newN = product(newExtents);
-        if (newN != size()) throw std::runtime_error("Tensor::reshape: size mismatch");
-        _extents.assign(newExtents.begin(), newExtents.end());
+    constexpr void fill(const T& value) noexcept {
+        if constexpr (_all_static) {
+            for (auto& elem : _data) {
+                elem = value;
+            }
+        } else {
+            std::ranges::fill(_data, value); // constexpr from C++26 onwards
+        }
     }
 
-    // --- strides (row-major) ---
-    [[nodiscard]] std::pmr::vector<std::size_t> strides() const {
-        std::pmr::vector<std::size_t> s(_extents.get_allocator().resource());
-        s.resize(rank());
-        if (rank() == 0) return s;
-        std::size_t stride = 1;
-        for (std::size_t i = rank(); i-- > 0;) {
-            s[i] = stride;
-            stride *= _extents[i];
-        }
-        return s;
+    void reshape(std::initializer_list<std::size_t> newExtents) requires (!_all_static) { reshape(std::span(newExtents)); }
+
+    template<std::ranges::range Range>
+    requires (std::same_as<std::ranges::range_value_t<Range>, std::size_t>)
+    void reshape(const Range& newExtents) requires (!_all_static) {
+        const std::size_t newN = product(std::span(newExtents));
+        if (newN != size()) throw std::runtime_error("Tensor::reshape: size mismatch");
+        _extents.assign(std::ranges::begin(newExtents), std::ranges::end(newExtents));
     }
 
 #if defined(TENSOR_HAVE_MDSPAN)
-    auto view() noexcept {
+    auto to_mdspan() noexcept {
         using index_t = std::size_t;
         auto e = _extents; // copy to ensure a contiguous buffer for constructor
         // Use layout_right (row-major)
         return std::mdspan<T, std::dextents<index_t, std::dynamic_extent>>(data(), e);
     }
-    auto view() const noexcept {
+    auto to_mdspan() const noexcept {
         using index_t = std::size_t;
         auto e = _extents;
         return std::mdspan<const T, std::dextents<index_t, std::dynamic_extent>>(data(), e);
@@ -470,7 +813,7 @@ struct Tensor {
 #else
     template<bool is_const>
     struct View {
-        using TPtr = std::conditional_t<is_const, const T*, T*>;
+        using TPtr = std::conditional_t<is_const, const_pointer, pointer>;
 
     private:
         TPtr ptr_;
@@ -486,19 +829,15 @@ struct Tensor {
         auto strides() const noexcept { return std::span<const std::size_t>(strides_); }
     };
 
-    [[nodiscard]] auto view() noexcept {
-        return View<false>{ data(), extentsSpan(), strides() };
-    }
-    [[nodiscard]] auto view() const noexcept {
-        return View<true>{ data(), extentsSpan(), strides() };
-    }
+    [[nodiscard]] auto to_mdspan() noexcept { return View<false>{ data(), extents(), strides() }; }
+    [[nodiscard]] auto to_mdspan() const noexcept { return View<true>{ data(), extents(), strides() }; }
 #endif
 
     // missing: subspan -- intentional for the time being
 
     template<std::ranges::range Range>
     requires (std::same_as<std::ranges::range_value_t<Range>, T> && !std::same_as<Range, std::initializer_list<T>>)
-    Tensor& operator=(const Range& range) {
+    constexpr Tensor& operator=(const Range& range) {
         if (std::ranges::size(range) != size()) {
             throw std::runtime_error("Range size doesn't match tensor size for assignment");
         }
@@ -506,13 +845,22 @@ struct Tensor {
         return *this;
     }
 
-    Tensor& operator=(const T& value) {
-        std::ranges::fill(_data, value);
+    constexpr Tensor& operator=(const T& value) {
+        fill(value);
         return *this;
     }
 };
 
 // ---- CTAD guides ----
+template<typename T>
+Tensor(std::initializer_list<T>) -> Tensor<T>;
+
+template<typename T>
+Tensor(std::initializer_list<std::initializer_list<T>>) -> Tensor<T>;
+
+template<typename T, std::size_t N>
+Tensor(const std::array<T, N>&) -> Tensor<T>;
+
 template <std::ranges::range Extents, std::ranges::range Data>
 Tensor(const Extents&, const Data&, std::pmr::memory_resource* = std::pmr::get_default_resource())
     -> Tensor<std::ranges::range_value_t<Data>>;

--- a/include/pmtv/type_helpers.hpp
+++ b/include/pmtv/type_helpers.hpp
@@ -5,129 +5,546 @@
 #include <concepts>
 #include <map>
 #include <memory>
+#include <memory_resource>
 #include <ranges>
 #include <span>
 #include <variant>
 #include <vector>
 
-#include <fmt/format.h>
 #include <pmtv/rva_variant.hpp>
+
+#if __has_include(<mdspan>)
+  #include <mdspan>
+  #define TENSOR_HAVE_MDSPAN 1
+#endif
 
 namespace pmtv {
 
-struct Tensor1d { explicit Tensor1d() = default; };
+struct tensor_extents_tag {};
+struct tensor_data_tag {};
 
-template <class _T>
-class Tensor {
-  public:
-    using T = std::conditional_t<std::same_as<_T, bool>, uint8_t, _T>;
+inline constexpr tensor_extents_tag extents_from{};
+inline constexpr tensor_data_tag data_from{};
+
+template <class T_>
+struct Tensor {
+    using T = std::conditional_t<std::same_as<T_, bool>, uint8_t, T_>;
     using value_type = T;
 
-    Tensor() = default;
+    std::pmr::vector<std::size_t> _extents;
+    std::pmr::vector<T> _data;
 
-    template <std::ranges::range Extents> requires (std::same_as<typename Extents::value_type, size_t>)
-    Tensor(const Extents& extents) : _extents(extents.begin(), extents.end()), _data(calculate_size(extents)) {}
+    static constexpr std::size_t product(std::span<const std::size_t> ex) {
+        std::size_t n{1UZ};
+        for (auto e : ex) {
+            if (e != 0UZ && n > (std::numeric_limits<std::size_t>::max)() / e)
+                throw std::length_error("Tensor: extents product overflow");
+            n *= e;
+        }
+        return n;
+    }
+    static constexpr std::size_t checked_size(std::span<const std::size_t> ex) {
+        return product(ex);
+    }
 
-    // I would like to be able to pass in a range and have it set up the extents as a single dim.
-    // I could do a range of value_type, but then it would be confused for integer/size_t cases which is correct.
-    // So for floating point types, I can have a constructor of extents, a constructor of values and a constructor
-    // of extents and values.
+    constexpr void bounds_check(std::span<const std::size_t> indices) const {
+        if (indices.size() != rank())
+            throw std::out_of_range("Tensor::at: incorrect number of indices");
+        for (std::size_t d = 0; d < rank(); ++d)
+            if (indices[d] >= _extents[d])
+                throw std::out_of_range("Tensor::at: index out of bounds");
+    }
 
-    // What if the data type is size_t?  How do I handle that?  There isn't a way to handle it.  What if I create a
-    // lamdba function.
-    // pmt
+    // row-major fold from a span
+    [[nodiscard]] constexpr std::size_t index_of(std::span<const std::size_t> idx) const noexcept {
+        std::size_t lin = 0UZ;
+        for (std::size_t d = 0; d < idx.size(); ++d) {
+            lin = lin * _extents[d] + idx[d];
+        }
+        return lin;
+    }
+
+    // row-major fold (variadic)
+    template <std::integral... Indices>
+    [[nodiscard]] constexpr std::size_t index_of(Indices... indices) const noexcept {
+        std::array<std::size_t, sizeof...(Indices)> a{ static_cast<std::size_t>(indices)... };
+        assert(a.size() == rank());
+        return index_of(std::span<const std::size_t>(a));
+    }
+
+    Tensor(const Tensor& other, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+    : _extents(other._extents.begin(), other._extents.end(), mr),
+      _data(other._data.begin(), other._data.end(), mr) {}
+
+    Tensor(Tensor&& other) noexcept = default;
+
+    Tensor& operator=(const Tensor& other) {
+        if (this != &other) {
+            _extents = other._extents;
+            _data = other._data;
+        }
+        return *this;
+    }
+    Tensor& operator=(Tensor&& other) noexcept = default;
+
+    explicit Tensor(std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+        : _extents(mr), _data(mr) {}
+
+    template <std::ranges::range Extents>
+        requires std::same_as<std::ranges::range_value_t<Extents>, std::size_t>
+    explicit Tensor(const Extents& extents,
+           std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+        : _extents(extents.begin(), extents.end(), mr),
+          _data(checked_size(_extents), mr) {}
+
+    Tensor(std::initializer_list<std::size_t> extents,
+           std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+        : _extents(extents.begin(), extents.end(), mr),
+          _data(checked_size(_extents), mr) {}
 
     template <std::ranges::range Extents, std::ranges::range Data>
-    requires  (std::same_as<typename Extents::value_type, size_t> && std::same_as<typename Data::value_type, T>)
-    Tensor(const Extents& extents, const Data& data) : _extents(extents.begin(), extents.end()), _data(data.begin(), data.end()) {
-        if (calculate_size(extents) != data.size()) {
-            throw std::runtime_error(fmt::format("Data size = {} doesn't match extents size = {}", data.size(), calculate_size(extents)));
+    requires (std::same_as<std::ranges::range_value_t<Extents>, std::size_t>
+        && std::same_as<std::ranges::range_value_t<Data>, T>)
+    Tensor(const Extents& extents, const Data& data, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+        : _extents(extents.begin(), extents.end(), mr), _data(data.begin(), data.end(), mr) {
+        if (_data.size() != checked_size(_extents)) {
+            throw std::runtime_error("Tensor: data size doesn't match extents product.");
         }
     }
 
+    template<std::ranges::range Range>
+    requires std::same_as<std::ranges::range_value_t<Range>, std::size_t>
+    Tensor(tensor_extents_tag, const Range& extents, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+    : _extents(extents.begin(), extents.end(), mr), _data(checked_size(_extents), mr) {}
+
+    template<std::ranges::range Range>
+    requires std::same_as<std::ranges::range_value_t<Range>, T>
+    Tensor(tensor_data_tag, const Range& data, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+        : _extents({std::size_t(std::ranges::size(data))}, mr), _data(data.begin(), data.end(), mr) {}
+
+    Tensor(std::size_t count, const T& value, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+        : _extents({count}, mr), _data(count, value, mr) {}
+
+    template<std::input_iterator InputIt>
+    Tensor(InputIt first, InputIt last, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+        : _extents(mr), _data(first, last, mr) { _extents.push_back(_data.size()); }
+
+    // Usage examples:
+    /**
+    std::vector<std::size_t> v{10, 20, 30};
+    Tensor<std::size_t> t1(extents_from, v);  // Clear: extents {10,20,30}
+    Tensor<std::size_t> t2(data_from, v);     // Clear: 1D data {10,20,30}
+    */
+
+
+    /**===== std::vector/std::pmr::vector COMPATIBILITY ===== */
+
     template <std::ranges::range Data>
-    requires  (std::same_as<typename Data::value_type, T>)
-    Tensor(Tensor1d, const Data& data) : _extents(1, data.size()), _data(data.begin(), data.end()) {}
+    requires std::same_as<std::ranges::range_value_t<Data>, T>
+    Tensor(std::initializer_list<std::size_t> extents, const Data& data,
+        std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+    : _extents(extents.begin(), extents.end(), mr), _data(data.begin(), data.end(), mr) {
+        if (_data.size() != checked_size(_extents)) {
+            throw std::runtime_error("Tensor: data size doesn't match extents product.");
+        }
+    }
 
-    Tensor(Tensor1d, std::initializer_list<T> data) : _extents(1, data.size()), _data(data.begin(), data.end()) {}
-    Tensor(Tensor1d, size_t length) : _extents(1, length), _data(length) {}
+    template<class U, class Allocator>
+    requires std::same_as<U, T>
+    explicit Tensor(const std::vector<U, Allocator>& vec, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+        : _extents({vec.size()}, mr), _data(vec.begin(), vec.end(), mr) {}
 
-    Tensor(std::initializer_list<size_t> extents) : _extents(extents), _data(calculate_size(extents)) {}
+    template<class U>
+    requires std::same_as<U, T>
+    explicit Tensor(const std::pmr::vector<U>& vec, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+        : _extents({vec.size()}, mr), _data(vec.begin(), vec.end(), mr) {}
 
-    constexpr std::span<const size_t> extents() const noexcept { return std::span(_extents); }
-    constexpr std::size_t size() const noexcept { return _data.size(); }
-    constexpr T* data() noexcept { return _data.data(); }
-    constexpr const T* data() const noexcept { return _data.data(); }
-    constexpr std::span<T> data_span() noexcept {return std::span(_data); }
-    constexpr std::span<const T> data_span() const noexcept {return std::span(_data); }
+    template<class U>
+    requires std::same_as<U, T>
+    explicit Tensor(std::pmr::vector<U>&& vec, std::pmr::memory_resource* mr = std::pmr::get_default_resource())
+        : _extents({vec.size()}, mr), _data(std::move(vec)) {
+        if (_data.get_allocator().resource() != mr) {
+            _data = std::pmr::vector<T>(std::make_move_iterator(_data.begin()), std::make_move_iterator(_data.end()), mr);
+        }
+    }
 
-    // Templated multi-bracket operator
+    template<class U, class Allocator>
+    requires std::same_as<U, T>
+    Tensor& operator=(const std::vector<U, Allocator>& vec) {
+        _extents = {vec.size()};
+        _data.assign(vec.begin(), vec.end());
+        return *this;
+    }
+
+    template<class U>
+    requires std::same_as<U, T>
+    Tensor& operator=(const std::pmr::vector<U>& vec) {
+        _extents = {vec.size()};
+        _data.assign(vec.begin(), vec.end());
+        return *this;
+    }
+
+    explicit constexpr operator std::vector<T>() const {
+        if (rank() != 1) {
+            throw std::runtime_error("Can only convert 1D tensors to std::vector");
+        }
+        return std::vector<T>(_data.begin(), _data.end());
+    }
+
+    explicit constexpr operator std::pmr::vector<T>() const {
+        if (rank() != 1) {
+            throw std::runtime_error("Can only convert 1D tensors to std::pmr::vector");
+        }
+        return std::pmr::vector<T>(_data.begin(), _data.end(), _data.get_allocator().resource());
+    }
+
+    // 1D vector compatibility functions
+    [[nodiscard]] std::size_t capacity() const noexcept { return _data.capacity(); }
+    void reserve(std::size_t new_cap) { _data.reserve(new_cap); }
+    void shrink_to_fit() { _data.shrink_to_fit();  }
+    void clear() noexcept {
+        _extents.clear();
+        _data.clear();
+    }
+
+    // Resize specific dimension
+    void resize_dim(std::size_t dim, std::size_t new_extent) {
+        if (dim >= rank()) {
+            throw std::out_of_range("resize_dim: dimension out of range");
+        }
+
+        if (_extents[dim] == new_extent) {
+            return;
+        }
+
+        _extents[dim] = new_extent;
+        std::size_t new_total_size = product(_extents);
+
+        _data.resize(new_total_size); // May need more sophisticated copying for interior dimensions
+        // this is a simplified version - the full implementation would need element-wise padding/truncating
+    }
+
+    void resize(std::initializer_list<std::size_t> new_extents, const T& value = {}) {
+        resize(std::span(new_extents), value);
+    }
+
+    template<std::ranges::range Range>
+    requires std::same_as<std::ranges::range_value_t<Range>, std::size_t>
+    void resize(const Range& new_extents, const T& value = {}) {
+        if (new_extents.empty()) { // clear tensor
+            clear();
+            return;
+        }
+
+        std::size_t new_size = product(new_extents);
+        _extents.assign(new_extents.begin(), new_extents.end());
+        _data.assign(new_size, value);
+    }
+
+    [[nodiscard]] T& front() {
+        if (empty()) throw std::runtime_error("front() on empty tensor");
+        return _data.front();
+    }
+
+    [[nodiscard]] const T& front() const {
+        if (empty()) throw std::runtime_error("front() on empty tensor");
+        return _data.front();
+    }
+
+    [[nodiscard]] T& back() {
+        if (empty()) throw std::runtime_error("back() on empty tensor");
+        return _data.back();
+    }
+
+    [[nodiscard]] const T& back() const {
+        if (empty()) throw std::runtime_error("back() on empty tensor");
+        return _data.back();
+    }
+
+    void push_back(const T& value) {
+        if (rank() > 1) {
+            _extents = {size()};  // Flatten to 1D
+        } else if (rank() == 0) {
+            _extents = {0};
+        }
+        _data.push_back(value);
+        ++_extents[0];
+    }
+
+    void push_back(T&& value) {
+        if (rank() > 1) {
+            _extents = {size()};
+        } else if (rank() == 0) {
+            _extents = {0};
+        }
+        _data.push_back(std::move(value));
+        ++_extents[0];
+    }
+
+    template<class... Args>
+    T& emplace_back(Args&&... args) {
+        if (rank() > 1) {
+            _extents = {size()};
+        } else if (rank() == 0) {
+            _extents = {0};
+        }
+        auto& ref = _data.emplace_back(std::forward<Args>(args)...);
+        ++_extents[0];
+        return ref;
+    }
+
+    void pop_back() {
+        if (empty()) throw std::runtime_error("pop_back on empty tensor");
+
+        if (rank() <= 1) {
+            _data.pop_back();
+            if (rank() == 1) {
+                --_extents[0];
+                if (_extents[0] == 0) {
+                    _extents.clear();
+                }
+            }
+        } else {
+            _extents = {size()};
+            _data.pop_back();
+            --_extents[0];
+        }
+    }
+
+    // Assignment operations
+    template<std::ranges::range Range>
+        requires std::same_as<std::ranges::range_value_t<Range>, T>
+    Tensor& assign(const Range& range) {
+        _extents = {static_cast<std::size_t>(std::ranges::size(range))};
+        _data.assign(range.begin(), range.end());
+        return *this;
+    }
+
+    Tensor& operator=(std::initializer_list<T> initializer_list) {
+        assign(initializer_list);
+        return *this;
+    }
+
+    void assign(std::size_t count, const T& value) {
+        _extents = {count};
+        _data.assign(count, value);
+    }
+
+    void swap(Tensor& other) noexcept {
+        _extents.swap(other._extents);
+        _data.swap(other._data);
+    }
+
+    // --- basic props ---
+    [[nodiscard]] constexpr std::size_t rank()   const noexcept { return _extents.size(); }
+    [[nodiscard]] constexpr std::size_t size()   const noexcept { return _data.size(); }
+    [[nodiscard]] constexpr bool        empty()  const noexcept { return _data.empty(); }
+    [[nodiscard]] constexpr std::size_t extent(std::size_t d) const noexcept { return _extents[d]; }
+    [[nodiscard]] constexpr std::span<const std::size_t> extentsSpan() const noexcept { return _extents; }
+
+    // --- iterators / STL compat ---
+    [[nodiscard]] T*       data()       noexcept { return _data.data(); }
+    [[nodiscard]] const T* data() const noexcept { return _data.data(); }
+    auto begin() noexcept { return _data.begin(); }
+    auto end()   noexcept { return _data.end(); }
+    auto begin() const noexcept { return _data.begin(); }
+    auto end()   const noexcept { return _data.end(); }
+    auto cbegin() const noexcept { return _data.cbegin(); }
+    auto cend()   const noexcept { return _data.cend(); }
+
+    [[nodiscard]] constexpr std::span<const size_t> extents() const noexcept { return std::span(_extents); }
+    [[nodiscard]] constexpr std::span<T> data_span() noexcept {return std::span(_data); }
+    [[nodiscard]] constexpr std::span<const T> data_span() const noexcept {return std::span(_data); }
+
+    // for vector-like compatibility
+    [[nodiscard]] T& operator[](std::size_t idx) noexcept {
+        assert(rank() == 1);
+        return _data[idx];
+    }
+    constexpr const T& operator[](std::size_t idx) const noexcept {
+        assert(rank() == 1);
+        return _data[idx];
+    }
+    // Templated multi-bracket operator - unchecked (similar to vector '[..]' to 'at(..)'
     template <std::integral... Indices>
-    constexpr T& operator[](Indices... indices) {
-        assert((sizeof...(indices) == _extents.size()) && "incorrect number of indices");
-        return _data[calculate_index(indices...)];
-        //return _data[calculate_index({static_cast<std::size_t>(indices)...})];
+    [[nodiscard]] T& operator[](Indices... idx)       noexcept { return _data[index_of(idx...)]; }
+    template <std::integral... Indices>
+    constexpr const T& operator[](Indices... idx) const noexcept { return _data[index_of(idx...)]; }
+
+    // Checked access (throws std::out_of_range)
+    [[nodiscard]] T& at(std::span<const std::size_t> indices) {
+        bounds_check(indices);
+        return _data[index_of(indices)];
+    }
+    [[nodiscard]] const T& at(std::span<const std::size_t> indices) const {
+        bounds_check(indices);
+        return _data[index_of(indices)];
     }
 
     template <std::integral... Indices>
-    [[nodiscard]] constexpr const T& operator[](Indices... indices) const {
-        assert(sizeof...(indices) == _extents.size() && "incorrect number of indices");
-        return _data[calculate_index({static_cast<std::size_t>(indices)...})];
+    [[nodiscard]] T& at(Indices... indices) {
+        std::array<std::size_t, sizeof...(Indices)> a{ static_cast<std::size_t>(indices)... };
+        bounds_check(a);
+        return at(std::span<const std::size_t>(a));
     }
 
-    const T& get(const std::span<size_t>& indices) const {
-        return _data[calculate_index(indices)];
+    template <std::integral... Indices>
+    [[nodiscard]] const T& at(Indices... indices) const {
+        std::array<std::size_t, sizeof...(Indices)> a{ static_cast<std::size_t>(indices)... };
+        bounds_check(a);
+        return at(std::span<const std::size_t>(a));
     }
 
-    constexpr bool operator==(const Tensor<T>& other ) const noexcept {
+    constexpr auto operator<=>(const Tensor<T>& other) const noexcept {
+        if (auto cmp = _extents <=> other._extents; cmp != 0) return cmp;
+        return _data <=> other._data;
+    }
+
+    constexpr bool operator==(const Tensor<T>& other) const noexcept {
         return _extents == other._extents && _data == other._data;
     }
 
-    constexpr bool operator!=(const Tensor<T>& other) const noexcept { return ! operator==(other); }
-
-    //operator std::mdspan<T, std::dynamic_extent>() const {
-    //    return std::mdspan<T, std::dynamic_extent>(_data.data(), _data.size());
-    //}
-  private:
-    std::vector<std::size_t> _extents;
-    std::vector<T> _data;
-
-    constexpr std::size_t calculate_size(std::span<const size_t> extents) const noexcept {
-        std::size_t size = 1;
-        for (size_t extent : extents) {
-            size *= extent;
-        }
-        return size;
+    template<class U, class Allocator>
+    requires std::same_as<U, T>
+    constexpr bool operator==(const std::vector<U, Allocator>& vec) const noexcept {
+        return rank() == 1 && _extents[0] == vec.size() && std::ranges::equal(_data, vec);
     }
 
-    std::size_t calculate_index(std::span<const std::size_t> indices) const {
-        assert(indices.size() == _extents.size() && "incorrect number of indices");
-        std::size_t index = 0;
+    template<class U, class Allocator>
+    requires std::same_as<U, T>
+    constexpr friend bool operator==(const std::vector<U, Allocator>& vec, const Tensor<T>& tensor) noexcept {
+        return tensor == vec;
+    }
+
+    template<class U>
+    requires std::same_as<U, T>
+    bool operator==(const std::pmr::vector<U>& vec) const noexcept {
+        return rank() == 1 && _extents[0] == vec.size() && std::ranges::equal(_data, vec);
+    }
+
+    template<class U>
+    requires std::same_as<U, T>
+    friend bool operator==(const std::pmr::vector<U>& vec, const Tensor<T>& tensor) noexcept {
+        return tensor == vec;
+    }
+
+    void fill(const T& v) { std::ranges::fill(_data, v); }
+
+
+
+    void reshape(std::initializer_list<std::size_t> newExtents) { reshape(std::span(newExtents)); }
+
+    template<std::ranges::range Range>
+    requires std::same_as<std::ranges::range_value_t<Range>, std::size_t>
+    void reshape(const Range& newExtents) { // reshape without moving data; preserves total size
+        const std::size_t newN = product(newExtents);
+        if (newN != size()) throw std::runtime_error("Tensor::reshape: size mismatch");
+        _extents.assign(newExtents.begin(), newExtents.end());
+    }
+
+    // --- strides (row-major) ---
+    [[nodiscard]] std::pmr::vector<std::size_t> strides() const {
+        std::pmr::vector<std::size_t> s(_extents.get_allocator().resource());
+        s.resize(rank());
+        if (rank() == 0) return s;
         std::size_t stride = 1;
-        for (int i = static_cast<int>(_extents.size()) - 1; i >= 0; --i) {
-            index += indices[i] * stride;
+        for (std::size_t i = rank(); i-- > 0;) {
+            s[i] = stride;
             stride *= _extents[i];
         }
-        return index;
+        return s;
     }
 
-    template <std::integral... Indices>
-    constexpr std::size_t calculate_index(Indices... indices) const noexcept {
-        static_assert((std::is_convertible_v<Indices, std::size_t> && ...), "Indices must be convertible to std::size_t");
-        assert(sizeof...(indices) == _extents.size() && "Incorrect number of indices");
-        return calculate_index_impl<0>(static_cast<std::size_t>(indices)...);
+#if defined(TENSOR_HAVE_MDSPAN)
+    auto view() noexcept {
+        using index_t = std::size_t;
+        auto e = _extents; // copy to ensure a contiguous buffer for constructor
+        // Use layout_right (row-major)
+        return std::mdspan<T, std::dextents<index_t, std::dynamic_extent>>(data(), e);
     }
+    auto view() const noexcept {
+        using index_t = std::size_t;
+        auto e = _extents;
+        return std::mdspan<const T, std::dextents<index_t, std::dynamic_extent>>(data(), e);
+    }
+#else
+    template<bool is_const>
+    struct View {
+        using TPtr = std::conditional_t<is_const, const T*, T*>;
 
-    template <std::size_t N, typename First, typename... Rest>
-    constexpr std::size_t calculate_index_impl(First first, Rest... rest) const noexcept {
-        if constexpr (N + 1 == sizeof...(Rest) + 1) {
-            return first;
-        } else {
-            return first * _extents[N] + calculate_index_impl<N + 1>(rest...);
+    private:
+        TPtr ptr_;
+        std::span<const std::size_t> extents_;
+        std::pmr::vector<std::size_t> strides_;
+
+    public:
+        View(TPtr ptr, std::span<const std::size_t> ex, std::pmr::vector<std::size_t> st)
+            : ptr_(ptr), extents_(ex), strides_(std::move(st)) {}
+
+        TPtr data() const noexcept { return ptr_; }
+        auto extents() const noexcept { return extents_; }
+        auto strides() const noexcept { return std::span<const std::size_t>(strides_); }
+    };
+
+    [[nodiscard]] auto view() noexcept {
+        return View<false>{ data(), extentsSpan(), strides() };
+    }
+    [[nodiscard]] auto view() const noexcept {
+        return View<true>{ data(), extentsSpan(), strides() };
+    }
+#endif
+
+    // missing: subspan -- intentional for the time being
+
+    template<std::ranges::range Range>
+    requires (std::same_as<std::ranges::range_value_t<Range>, T> && !std::same_as<Range, std::initializer_list<T>>)
+    Tensor& operator=(const Range& range) {
+        if (std::ranges::size(range) != size()) {
+            throw std::runtime_error("Range size doesn't match tensor size for assignment");
         }
+        std::ranges::copy(range, _data.begin());
+        return *this;
     }
 
+    Tensor& operator=(const T& value) {
+        std::ranges::fill(_data, value);
+        return *this;
+    }
 };
+
+// ---- CTAD guides ----
+template <std::ranges::range Extents, std::ranges::range Data>
+Tensor(const Extents&, const Data&, std::pmr::memory_resource* = std::pmr::get_default_resource())
+    -> Tensor<std::ranges::range_value_t<Data>>;
+
+template<std::ranges::range Range>
+Tensor(tensor_data_tag, const Range&, std::pmr::memory_resource* = std::pmr::get_default_resource())
+    -> Tensor<std::ranges::range_value_t<Range>>;
+
+template<std::ranges::range Range>
+Tensor(tensor_extents_tag, const Range&, std::pmr::memory_resource* = std::pmr::get_default_resource())
+    -> Tensor<std::ranges::range_value_t<Range>>;
+
+template<class T>
+Tensor(std::size_t, const T&, std::pmr::memory_resource* = std::pmr::get_default_resource()) -> Tensor<T>;
+
+template<std::input_iterator InputIt>
+Tensor(InputIt, InputIt, std::pmr::memory_resource* = std::pmr::get_default_resource())
+    -> Tensor<typename std::iterator_traits<InputIt>::value_type>;
+
+template<class T, class Allocator>
+Tensor(const std::vector<T, Allocator>&, std::pmr::memory_resource* = std::pmr::get_default_resource()) -> Tensor<T>;
+
+template<class T>
+Tensor(const std::pmr::vector<T>&, std::pmr::memory_resource* = std::pmr::get_default_resource()) -> Tensor<T>;
+
+template<class T>
+Tensor(std::pmr::vector<T>&&, std::pmr::memory_resource* = std::pmr::get_default_resource()) -> Tensor<T>;
+
+template<class T>
+void swap(Tensor<T>& lhs, Tensor<T>& rhs) noexcept {
+    lhs.swap(rhs);
+}
 
 template <class T>
 struct is_pmt_tensor : std::false_type {};
@@ -205,7 +622,7 @@ concept UniformVector =
 
 // A vector of bool can be optimized to one bit per element, so it doesn't satisfy UniformVector
 template <typename T>
-concept UniformBoolVector = 
+concept UniformBoolVector =
     std::ranges::range<T> && std::same_as<typename T::value_type, bool>;
 
 template <typename T>

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('pmt', 'cpp',
   version : '0.0.2',
   meson_version: '>=0.63.0',
   license : 'GPLv3',
-  default_options : ['cpp_std=c++20', 'warning_level=3'])
+  default_options : ['cpp_std=c++23', 'werror=false', 'warning_level=3'])
 
 cc = meson.get_compiler('cpp')
 warnings_as_errors = get_option('warnings_as_errors') # Define this option in your meson_options.txt

--- a/test/meson.build
+++ b/test/meson.build
@@ -12,6 +12,7 @@ qa_srcs = ['qa_scalar',
            'qa_vector_of_pmts',
            'qa_map',
            'qa_string',
+           'qa_tensor',
            'qa_reflection'
           ]
 deps = [pmt_dep, 

--- a/test/qa_map.cpp
+++ b/test/qa_map.cpp
@@ -20,7 +20,7 @@ TEST(PmtMap, EmptyMap) {
     auto empty = pmt(map_t{});
     auto v = get_map(empty);
     v["abc"] = pmt(uint64_t(4));
-    v["xyz"] = pmt(Tensor<double>(Tensor1d(), { 1, 2, 3, 4, 5 }));
+    v["xyz"] = pmt(Tensor<double>(pmtv::data_from, std::array<double, 5UZ>{ 1, 2, 3, 4, 5 }));
 
     using namespace std::literals;
     using namespace std::string_literals;
@@ -43,7 +43,7 @@ TEST(PmtMap, EmptyMap) {
 
 TEST(PmtMap, PmtMapTests) {
     std::complex<float> val1(1.2f, -3.4f);
-    Tensor<int32_t> val2(Tensor1d(), { 44, 34563, -255729, 4402 });
+    Tensor<int32_t> val2(pmtv::data_from, std::array{ 44, 34563, -255729, 4402 });
 
     // Create the PMT map
     pmtv::map_t input_map({
@@ -70,7 +70,7 @@ TEST(PmtMap, PmtMapTests) {
 TEST(PmtMap, MapSerialize) {
     std::complex<float> val1(1.2f, -3.4f);
     std::vector<int32_t> vec{44, 34563, -255729, 4402};
-    Tensor<int32_t> val2(Tensor1d(), vec);
+    Tensor<int32_t> val2(pmtv::data_from, vec);
 
     // Create the PMT map
     map_t input_map({
@@ -88,7 +88,7 @@ TEST(PmtMap, MapSerialize) {
 TEST(PmtMap, get_as) {
     std::complex<float> val1(1.2f, -3.4f);
     std::vector<int32_t> vec{44, 34563, -255729, 4402};
-    Tensor<int32_t> val2(Tensor1d(), vec);
+    Tensor<int32_t> val2(pmtv::data_from, vec);
 
     // Create the PMT map
     pmtv::map_t input_map({
@@ -108,7 +108,7 @@ TEST(PmtMap, get_as) {
 TEST(PmtMap, base64) {
     std::complex<float> val1(1.2f, -3.4f);
     std::vector<int32_t> vec{44, 34563, -255729, 4402};
-    Tensor<int32_t> val2(Tensor1d(), vec);
+    Tensor<int32_t> val2(pmtv::data_from, vec);
 
     // Create the PMT map
     pmtv::map_t input_map({
@@ -127,7 +127,7 @@ TEST(PmtMap, base64) {
 TEST(PmtMap, fmt) {
     std::complex<float> val1(1.2f, -3.4f);
     std::vector<int32_t> vec{44, 34563, -255729, 4402};
-    Tensor<int32_t> val2(Tensor1d(), vec);
+    Tensor<int32_t> val2(pmtv::data_from, vec);
 
     // Create the PMT map
     pmtv::map_t input_map({

--- a/test/qa_scalar.cpp
+++ b/test/qa_scalar.cpp
@@ -50,12 +50,12 @@ double PmtScalarFixture<double>::get_value() {
 
 template<>
 std::complex<float> PmtScalarFixture<std::complex<float>>::get_value() {
-    return std::complex<float>(4.1f, -4.1f);
+    return { 4.1f, -4.1f };
 }
 
 template<>
 std::complex<double> PmtScalarFixture<std::complex<double>>::get_value() {
-    return std::complex<double>(4.1, -4.1);
+    return { 4.1, -4.1 };
 }
 
 TYPED_TEST_SUITE(PmtScalarFixture, testing_types);
@@ -108,7 +108,7 @@ TYPED_TEST(PmtScalarFixture, PmtScalarValue) {
     x = value;
     EXPECT_TRUE(x == value);
     // pmt e({{"abc", 123}, {"you and me", "baby"}});
-    pmt e(Tensor<int32_t>(Tensor1d(), { 4, 5, 6 }));
+    pmt e(Tensor<int32_t>(pmtv::data_from, std::array{ 4, 5, 6 }));
 }
 
 TYPED_TEST(PmtScalarFixture, PmtScalarPrint) {

--- a/test/qa_tensor.cpp
+++ b/test/qa_tensor.cpp
@@ -16,11 +16,261 @@
 
 #include <pmtv/pmt.hpp>
 
+#include <print>
+
 using pmtv::Tensor;
 
 // ============================================================================
 // BASIC FUNCTIONALITY (Types, Construction, Properties)
 // ============================================================================
+
+// ---- tiny constexpr det (2×2, 3×3) using [] ----
+template <class T, std::size_t N> requires (N == 2)
+constexpr T det(const Tensor<T, N, N>& A) {
+    return A[0,0]*A[1,1] - A[0,1]*A[1,0];
+}
+template <class T, std::size_t N> requires (N == 3)
+constexpr T det(const Tensor<T, N, N>& A) {
+    return  A[0,0]*(A[1,1]*A[2,2] - A[1,2]*A[2,1])
+          - A[0,1]*(A[1,0]*A[2,2] - A[1,2]*A[2,0])
+          + A[0,2]*(A[1,0]*A[2,1] - A[1,1]*A[2,0]);
+}
+
+TEST(TensorBasic, UserAPI) {
+    // Case 1: fully dynamic rank & extents
+    std::vector<double> dynData{1,2,3,4,5,6};
+    Tensor<double> A({3UZ,2UZ}, dynData);
+    std::println("A: rank={}, size={}, A[2,1]={}", A.rank(), A.size(), A[2,1]);
+
+    // Case 2: rank=1 with dynamic extent → data-only ctor
+    Tensor<double, std::dynamic_extent> B({1,2,3,4,5});
+    std::println("B: rank={}, size={}, B[4]={}", B.rank(), B.size(), B[4]);
+
+    // Case 3: fully static 2×3, ultra-compact
+    constexpr Tensor<double, 2UZ, 3UZ> C({
+        1, 2, 3, // row 0
+        4, 5, 7  // row 1
+    });
+    static_assert(Tensor<double, 2UZ, 3UZ>::rank() == 2);
+    static_assert(Tensor<double, 2UZ, 3UZ>::extent<1>() == 3);
+    static_assert(sizeof(Tensor<double,2,3>) == sizeof(std::array<double,6>));
+
+    std::println("C: size={}, C[1,2]={}", C.size(), C[1,2]);
+
+    // constexpr proof for flat ctor
+    constexpr Tensor<double, 2UZ, 2UZ> D({1,2,3,4});
+    static_assert(det(D) == -2);
+    std::println("det(D) = {}", det(D));
+}
+
+TEST(TensorBasics, DefaultConstruction) {
+    Tensor<int> tensor;
+    EXPECT_EQ(tensor.rank(), 0UZ);
+    EXPECT_EQ(tensor.size(), 0UZ);
+    EXPECT_TRUE(tensor.empty());
+    EXPECT_EQ(tensor.capacity(), 0UZ);
+}
+
+TEST(TensorConstruction, StaticConstexprConstruction) {
+    constexpr Tensor<int, 2UZ, 2UZ> tensor{1, 2, 3, 4};
+    static_assert(tensor.size() == 4);
+    static_assert(decltype(tensor)::size() == 4);
+    static_assert((tensor[0, 0]) == 1);
+}
+
+TEST(TensorBasic, TypeSizes){
+    static_assert(sizeof(std::array<double, 3UZ>) >= 3UZ * sizeof(double));
+    static_assert(sizeof(std::array<std::size_t, 3UZ>) >= 3UZ * sizeof(std::size_t));
+    static_assert(sizeof(std::vector<double>) >= (sizeof(std::size_t) /* size */ + sizeof(std::size_t) /* capacity */ + sizeof(double*) /* begin() */));
+    static_assert(sizeof(std::pmr::vector<std::size_t>) >= (sizeof(std::vector<double>) + sizeof(double*) /* PMR allocator */ ));
+    static_assert(sizeof(std::pmr::vector<std::size_t>) > sizeof(std::vector<std::size_t>)); // usually 32 bytes on x86_64
+    static_assert(sizeof(Tensor<double>) == (sizeof(std::pmr::vector<std::size_t>) + sizeof(std::pmr::vector<double>)));
+    static_assert(sizeof(Tensor<double, std::dynamic_extent>) == (sizeof(std::array<std::size_t, 1UZ>) + sizeof(std::pmr::vector<double>)));
+    static_assert(sizeof(Tensor<double, 3UZ, 2UZ>) == 3UZ * 2UZ * sizeof(double));
+}
+
+// Add to TensorBasic tests
+TEST(TensorBasic, StaticTensorConstexpr) {
+    // Test fully static tensor constexpr operations
+    constexpr Tensor<int, 2UZ, 3UZ> mat{1, 2, 3, 4, 5, 6};
+    static_assert((mat[1, 2]) == 6UZ);
+    static_assert(mat.size() == 6UZ);
+    static_assert(Tensor<int, 2UZ, 3UZ>::rank() == 2UZ);
+    static_assert(Tensor<int, 2UZ, 3UZ>::size() == 6UZ);
+
+    // Test nested initializer list for 2D
+    constexpr Tensor<int, 2UZ, 3UZ> mat2{{1, 2, 3}, {4, 5, 6}};
+    static_assert(mat2[0, 0] == 1);
+    static_assert(mat2[1, 2] == 6);
+}
+
+TEST(TensorBasic, SemiStaticTensor) {
+    Tensor<int, std::dynamic_extent, std::dynamic_extent> tensor({3UZ, 4UZ});
+    EXPECT_EQ(tensor.rank(), 2UZ);
+    static_assert(Tensor<int, std::dynamic_extent, std::dynamic_extent>::rank() == 2UZ);
+    EXPECT_EQ(tensor.size(), 12UZ);
+
+    auto extents = tensor.extents();
+    EXPECT_EQ(extents[0], 3UZ);
+    EXPECT_EQ(extents[1], 4UZ);
+}
+
+TEST(TensorConversion, CrossTypeConstructors) {
+    // static to dynamic
+    constexpr Tensor<int, 2UZ, 3UZ> static_tensor{1, 2, 3, 4, 5, 6};
+    Tensor<int> dynamic_tensor(static_tensor);
+    EXPECT_EQ(dynamic_tensor.rank(), 2UZ);
+    EXPECT_EQ(dynamic_tensor.size(), 6UZ);
+    EXPECT_TRUE(std::ranges::equal(dynamic_tensor, static_tensor));
+
+    // assignment operator
+    Tensor<int> dynamic_tensor2;
+    dynamic_tensor2 = static_tensor;
+    EXPECT_TRUE(std::ranges::equal(dynamic_tensor2, static_tensor));
+
+    // dynamic to static with size check
+    Tensor<double> source({2UZ, 2UZ});
+    std::iota(source.begin(), source.end(), 1.0);
+    Tensor<double, 2UZ, 2UZ> target(source);
+    EXPECT_TRUE(std::ranges::equal(target, source));
+
+    // assignment operator
+    Tensor<double, 2UZ, 2UZ> target2;
+    target2 = source;
+    EXPECT_TRUE(std::ranges::equal(target, source));
+
+    // Wrong size should throw
+    Tensor<double> wrong_size({2UZ, 3UZ});
+    EXPECT_THROW((Tensor<double, 2UZ, 2UZ>(wrong_size)), std::runtime_error);
+
+    // assignment operator
+    Tensor<double, 2UZ, 2UZ> dest;
+    EXPECT_THROW((dest = wrong_size), std::runtime_error);
+
+    // Type conversion
+    Tensor<int, 2UZ, 2UZ> int_tensor{1, 2, 3, 4};
+    Tensor<double, 2UZ, 2UZ> double_tensor(int_tensor);
+    EXPECT_EQ((double_tensor[0, 0]), 1.0);
+}
+
+// Missing assignment operator tests - add these to your suite
+
+TEST(TensorAssignment, StaticToStaticSameTypeDifferentSize) {
+    Tensor<int, 2, 2> source{1, 2, 3, 4};
+    Tensor<int, 3, 3> target;
+
+    // Should throw due to size mismatch
+    EXPECT_THROW(target = source, std::runtime_error);
+}
+
+TEST(TensorAssignment, StaticToStaticDifferentType) {
+    Tensor<float, 2, 2> source{1.5f, 2.5f, 3.5f, 4.5f};
+    Tensor<int, 2, 2> target;
+
+    target = source;
+    EXPECT_EQ((target[0, 0]), 1);  // truncation
+    EXPECT_EQ((target[1, 1]), 4);
+}
+
+TEST(TensorAssignment, DynamicToStaticSizeCheck) {
+    Tensor<double> source({3UZ, 3UZ}, std::vector{1., 2., 3., 4., 5., 6., 7., 8., 9.});
+    Tensor<double, 2UZ, 2UZ> target;
+
+    // Size mismatch should throw
+    EXPECT_THROW(target = source, std::runtime_error);
+
+    // Correct size should work
+    Tensor<double> correct_source({2UZ, 2UZ}, std::vector{1., 2., 3., 4.});
+    EXPECT_NO_THROW(target = correct_source);
+}
+
+TEST(TensorAssignment, SelfAssignmentSafety) {
+    Tensor<int, 2UZ, 2UZ> static_tensor{1, 2, 3, 4};
+    Tensor<int> dynamic_tensor({2UZ, 2UZ}, std::vector{5, 6, 7, 8});
+
+    auto static_copy = static_tensor;
+    auto dynamic_copy = dynamic_tensor;
+
+    // safe self-assignment
+    static_tensor = static_tensor;
+    dynamic_tensor = dynamic_tensor;
+
+    EXPECT_EQ(static_tensor, static_copy);
+    EXPECT_EQ(dynamic_tensor, dynamic_copy);
+}
+
+TEST(TensorAssignment, ChainedAssignment) {
+    Tensor<int, 2, 2> source{1, 2, 3, 4};
+    Tensor<int, 2, 2> target1, target2, target3;
+
+    // Should support chaining
+    target3 = target2 = target1 = source;
+
+    EXPECT_EQ(target1, source);
+    EXPECT_EQ(target2, source);
+    EXPECT_EQ(target3, source);
+}
+
+TEST(TensorMethods, StaticTensorLimitations) {
+    constexpr Tensor<int, 3, 3> static_tensor{1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    // These should work
+    EXPECT_EQ(static_tensor.rank(), 2UZ);
+    EXPECT_EQ(static_tensor.size(), 9UZ);
+    EXPECT_EQ(static_tensor.extent(0), 3UZ);
+
+    // Can't clear, reshape, or resize static tensors
+    // These would be compile errors if uncommented:
+    // static_tensor.clear();  // ERROR: requires (!_all_static)
+    // static_tensor.reshape({9});  // ERROR: requires (!_all_static)
+}
+
+TEST(TensorEdgeCases, MixedOperations) {
+    // Start with static tensor
+    Tensor<int, 2, 3> static_t{1, 2, 3, 4, 5, 6};
+
+    // Convert to dynamic
+    Tensor<int> dynamic_t(static_t);
+
+    // Modify dynamic
+    dynamic_t.push_back(7);
+    EXPECT_EQ(dynamic_t.rank(), 1UZ);  // Flattened
+    EXPECT_EQ(dynamic_t.size(), 7UZ);
+
+    // Can't assign back to static (size mismatch)
+    // This would throw at runtime:
+    // static_t = dynamic_t;  // ERROR: can't change static tensor size
+}
+
+TEST(TensorEdgeCases, PMRResourcePropagation) {
+    std::array<std::byte, 1024> buffer;
+    std::pmr::monotonic_buffer_resource resource(buffer.data(), buffer.size());
+
+    // Create tensor with a custom resource
+    Tensor<int> t1({2, 3}, &resource);
+
+    // Copy constructor should use the same resource
+    Tensor<int> t2(t1, &resource);
+    EXPECT_EQ(t2._data.get_allocator().resource(), &resource);
+
+    // Converting constructor with resource
+    Tensor<double> t3(t1, &resource);
+    EXPECT_EQ(t3._data.get_allocator().resource(), &resource);
+}
+
+TEST(TensorBasic, TypeConversion) {
+    // static to dynamic
+    Tensor<double, 2UZ, 3UZ> static_tensor{{1, 2, 3}, {4, 5, 6}};
+    Tensor<double> dynamic_tensor(static_tensor);  // converts to fully dynamic
+
+    // dynamic to static (with runtime check)
+    Tensor<float> source({2UZ, 2UZ});
+    Tensor<float, 2UZ, 2UZ> target(source);  // throws if dimensions don't match
+
+    // type conversion
+    Tensor<int, 3UZ, 3UZ> int_tensor{/*...*/};
+    Tensor<double, 3UZ, 3UZ> double_tensor(int_tensor);  // int -> double conversion
+}
 
 TEST(TensorBasics, TypeTraits) {
     // Test bool -> uint8_t conversion
@@ -34,12 +284,15 @@ TEST(TensorBasics, TypeTraits) {
     static_assert(!pmtv::PmtTensor<std::vector<int>>);
 }
 
-TEST(TensorBasics, DefaultConstruction) {
-    Tensor<int> tensor;
-    EXPECT_EQ(tensor.rank(), 0UZ);
-    EXPECT_EQ(tensor.size(), 0UZ);
-    EXPECT_TRUE(tensor.empty());
-    EXPECT_EQ(tensor.capacity(), 0UZ);
+TEST(TensorTypes, SizeCalculations) {
+    // Verify memory layout expectations
+    static_assert(sizeof(Tensor<double, 3, 3>) == 9 * sizeof(double));
+    static_assert(sizeof(Tensor<double>) < sizeof(Tensor<double, 3UZ, 3UZ>));
+
+    // Test constexpr size/rank calculations
+    static_assert(Tensor<int, 2UZ, 3UZ>::size() == 6UZ);
+    static_assert(Tensor<int, 2UZ, 3UZ>::rank() == 2UZ);
+    static_assert(Tensor<int, 2UZ, 3UZ>::extent<1UZ>() == 3UZ);
 }
 
 TEST(TensorBasics, ExtentsConstruction) {
@@ -184,6 +437,19 @@ TEST(TensorVectorCompat, CrossTypeComparisons) {
     Tensor<int> matrix({2UZ, 2UZ});
     std::iota(matrix.begin(), matrix.end(), 1);
     EXPECT_FALSE(matrix == vec);  // Different rank
+}
+
+TEST(TensorSTL, IteratorCategories) {
+    Tensor<int> tensor({3, 4});
+
+    // Verify iterator types
+    static_assert(std::random_access_iterator<decltype(tensor.begin())>);
+    static_assert(std::contiguous_iterator<decltype(tensor.begin())>);
+
+    // Test iterator operations
+    auto it = tensor.begin();
+    EXPECT_EQ(it + 5, tensor.begin() + 5);  // Random access
+    EXPECT_EQ(std::to_address(it), tensor.data());  // Contiguous
 }
 
 // ============================================================================
@@ -531,14 +797,14 @@ TEST(TensorAdvanced, Views) {
     std::iota(tensor.begin(), tensor.end(), 0);
 
     // Non-const view
-    auto view = tensor.view();
+    auto view = tensor.to_mdspan();
     EXPECT_EQ(view.data(), tensor.data());
     EXPECT_EQ(view.extents().size(), 2UZ);
     EXPECT_EQ(view.strides().size(), 2UZ);
 
     // Const view
     const auto& const_tensor = tensor;
-    auto const_view = const_tensor.view();
+    auto const_view = const_tensor.to_mdspan();
     EXPECT_EQ(const_view.data(), tensor.data());
     #endif
 }
@@ -548,7 +814,7 @@ TEST(TensorAdvanced, MdspanIntegration) {
     Tensor<int> tensor({2, 3});
     std::iota(tensor.begin(), tensor.end(), 0);
 
-    auto view = tensor.view();
+    auto view = tensor.to_mdspan();
     EXPECT_EQ(view.extent(0), 2UZ);
     EXPECT_EQ(view.extent(1), 3UZ);
 
@@ -723,4 +989,194 @@ TEST(TensorStress, ManyOperations) {
         tensor.pop_back();
     }
     EXPECT_EQ(tensor.size(), 5000UZ);
+}
+
+TEST(TensorBoundary, MaximumDimensions) {
+    // Test with many dimensions (stress test rank handling)
+    std::vector<std::size_t> many_dims(10, 2);  // 10D tensor of 2^10 = 1024 elements
+    Tensor<int> high_rank_tensor(many_dims);
+
+    EXPECT_EQ(high_rank_tensor.rank(), 10);
+    EXPECT_EQ(high_rank_tensor.size(), 1024);
+
+    // Access with many indices - create vector first, then span
+    std::vector<std::size_t> zero_indices(10, 0);
+    high_rank_tensor.at(std::span<const std::size_t>(zero_indices)) = 42;
+    EXPECT_EQ(high_rank_tensor.at(std::span<const std::size_t>(zero_indices)), 42);
+}
+
+TEST(TensorBoundary, SingleElementTensorOperations) {
+    // 1x1x1x1 tensor (many dimensions, one element)
+    Tensor<int> single_elem({1, 1, 1, 1});
+    single_elem[0, 0, 0, 0] = 99;
+
+    EXPECT_EQ(single_elem.size(), 1);
+    EXPECT_EQ(single_elem.front(), 99);
+    EXPECT_EQ(single_elem.back(), 99);
+
+    // Reshape to different single-element shapes
+    single_elem.reshape({1});
+    EXPECT_EQ(single_elem[0], 99);
+}
+
+TEST(TensorBoundary, ExtentEdgeCases) {
+    // Extent size 1 in various positions
+    Tensor<int> tensor1({1, 5, 1});
+    EXPECT_EQ(tensor1.size(), 5);
+
+    // Very large single dimension
+    if constexpr (sizeof(std::size_t) >= 8) {  // Only on 64-bit systems
+        const std::size_t large_size = 1UL << 20;  // 1M elements
+        Tensor<char> large_tensor(large_size, 'x');
+        EXPECT_EQ(large_tensor.size(), large_size);
+        EXPECT_EQ(large_tensor.front(), 'x');
+        EXPECT_EQ(large_tensor.back(), 'x');
+    }
+}
+
+
+TEST(TensorBoundary, IndexingEdgeCases) {
+    Tensor<int> tensor({3, 4, 5});
+    std::iota(tensor.begin(), tensor.end(), 0);
+
+    // Test all corner indices - use parentheses to avoid macro parsing issues
+    EXPECT_EQ((tensor[0, 0, 0]), 0);                         // First element
+    EXPECT_EQ((tensor[2, 3, 4]), int(tensor.size() - 1));   // Last element
+
+    // Test stride boundaries
+    EXPECT_EQ((tensor[1, 0, 0]), 20);  // Second "plane"
+    EXPECT_EQ((tensor[0, 1, 0]), 5);   // Second "row"
+    EXPECT_EQ((tensor[0, 0, 1]), 1);   // Second "column"
+}
+
+TEST(TensorBoundary, AllocatorEdgeCases) {
+    auto* null_resource = std::pmr::null_memory_resource();
+
+    // static tensor should work (no allocation)
+    EXPECT_NO_THROW((Tensor<int, 2, 2>{}));
+
+    // dynamic tensor should fail on allocation attempt
+    EXPECT_THROW((Tensor<int>({2, 2}, null_resource)), std::bad_alloc);
+}
+
+TEST(TensorConstruction, NestedInitializerLists2D) {
+    // Your implementation supports 3D nested lists but you don't test them
+    Tensor<int, 2UZ, 3UZ> tensor{{1, 2, 3}, {4, 5, 6}};
+
+    EXPECT_EQ((tensor[0, 0]), 1);
+    EXPECT_EQ((tensor[1, 0]), 4);
+}
+
+TEST(TensorConstruction, NestedInitializerLists3D) {
+    // Your implementation supports 3D nested lists but you don't test them
+    Tensor<int, 2UZ, 2UZ, 2UZ> tensor{{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}};
+
+    EXPECT_EQ((tensor[0, 0, 0]), 1);
+    EXPECT_EQ((tensor[0, 1, 1]), 4);
+    EXPECT_EQ((tensor[1, 0, 0]), 5);
+    EXPECT_EQ((tensor[1, 1, 1]), 8);
+
+    // Wrong dimensions should throw
+    EXPECT_THROW((Tensor<int, 2, 2, 2>{{{1, 2, 3}, {4, 5, 6}}}), std::runtime_error);
+}
+
+TEST(TensorConstruction, MoveConstructorForVector) {
+    std::pmr::vector<int> vec{1, 2, 3, 4, 5};
+    Tensor<int> tensor(std::move(vec));
+
+    EXPECT_EQ(tensor.rank(), 1UZ);
+    EXPECT_EQ(tensor.size(), 5UZ);
+    EXPECT_EQ(tensor[0], 1);
+    // The vector should have been moved (though data pointer check is implementation-dependent)
+}
+
+TEST(TensorConstruction, AllocatorMismatchInMove) {
+    std::array<std::byte, 1024UZ> buffer1{};
+    std::array<std::byte, 1024UZ> buffer2{};
+    std::pmr::monotonic_buffer_resource resource1(buffer1.data(), buffer1.size());
+    std::pmr::monotonic_buffer_resource resource2(buffer2.data(), buffer2.size());
+
+    std::pmr::vector<int> vec({1, 2, 3, 4}, &resource1);
+
+    // Moving with different allocator should copy, not move
+    Tensor<int> tensor(std::move(vec), &resource2);
+
+    EXPECT_EQ(tensor.size(), 4);
+    EXPECT_EQ(tensor._data.get_allocator().resource(), &resource2);
+}
+
+TEST(TensorConstruction, InitializerListSizeErrors) {
+    // Static tensor with wrong size initializer
+    EXPECT_THROW((Tensor<int, 2, 2>{1, 2, 3}), std::runtime_error);  // Too few
+    EXPECT_THROW((Tensor<int, 2, 2>{1, 2, 3, 4, 5}), std::runtime_error);  // Too many
+}
+
+// Also fix the nodiscard warning:
+TEST(TensorBoundary, ZeroSizedDimensions) {
+    Tensor<int> tensor({3, 0, 2});
+    EXPECT_EQ(tensor.size(), 0);
+    EXPECT_EQ(tensor.rank(), 3);
+    EXPECT_TRUE(tensor.empty());
+
+    Tensor<int> all_zero({0, 0, 0});
+    EXPECT_EQ(all_zero.size(), 0);
+
+    // Operations on zero-sized tensors
+    EXPECT_NO_THROW(tensor.reshape({0}));
+
+    // Fix nodiscard warning by using std::ignore
+    EXPECT_THROW(std::ignore = tensor.front(), std::runtime_error);
+}
+
+TEST(TensorErrors, ConversionErrors) {
+    // Rank mismatch in conversion constructor
+    Tensor<int, 2, 2> source{1, 2, 3, 4};
+    // Semi-static rank mismatch
+    Tensor<int> dynamic_source({2, 2, 2});
+    EXPECT_THROW((Tensor<int, std::dynamic_extent, std::dynamic_extent>(dynamic_source)), std::runtime_error);
+}
+
+TEST(TensorErrors, ExtentsDataMismatch) {
+    std::vector<int> data{1, 2, 3, 4, 5, 6};
+
+    // Product doesn't match data size
+    EXPECT_THROW((Tensor<int>({2, 4}, data)), std::runtime_error);  // 8 != 6
+    EXPECT_THROW((Tensor<int>({3, 3}, data)), std::runtime_error);  // 9 != 6
+
+    // Empty extents with data
+    EXPECT_THROW((Tensor<int>({}, data)), std::runtime_error);
+}
+
+TEST(TensorErrors, IndexCalculationOverflow) {
+    // This might not throw in practice but tests edge case
+    const std::size_t max_val = std::numeric_limits<std::size_t>::max();
+
+    // Very large dimensions that could overflow in index calculation
+    EXPECT_THROW((Tensor<char>({max_val, max_val})), std::length_error);
+}
+
+TEST(TensorErrors, StaticTensorOperationErrors) {
+    Tensor<int, 2, 3> static_tensor{1, 2, 3, 4, 5, 6};
+
+    // Operations that should be compile-time errors are tested via concepts
+    // But runtime errors for inappropriate static tensor usage:
+
+    // Converting to vector with wrong rank
+    Tensor<int, 2, 3> matrix{1, 2, 3, 4, 5, 6};
+    EXPECT_THROW(std::ignore = static_cast<std::vector<int>>(matrix), std::runtime_error);
+}
+
+TEST(TensorErrors, PMRResourceExhaustion) {
+    auto* null_resource = std::pmr::null_memory_resource(); // always throws
+    EXPECT_THROW({ Tensor<int> tensor({10}, null_resource); }, std::bad_alloc);
+
+    // test with a vector construction that should fail
+    EXPECT_THROW({
+        Tensor<double> tensor(100, 3.14, null_resource);  // 100 elements with null allocator
+    }, std::bad_alloc);
+
+    EXPECT_THROW({
+        Tensor<int> tensor(null_resource);
+        tensor.push_back(42);  // fails on first allocation
+    }, std::bad_alloc);
 }

--- a/test/qa_tensor.cpp
+++ b/test/qa_tensor.cpp
@@ -1,0 +1,726 @@
+// qa_tensor.cpp - Reorganized and comprehensive test suite
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory_resource>
+#include <numeric>
+#include <ranges>
+#include <span>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+#include <pmtv/pmt.hpp>
+
+using pmtv::Tensor;
+
+// ============================================================================
+// BASIC FUNCTIONALITY (Types, Construction, Properties)
+// ============================================================================
+
+TEST(TensorBasics, TypeTraits) {
+    // Test bool -> uint8_t conversion
+    static_assert(std::same_as<typename Tensor<bool>::value_type, std::uint8_t>,
+                  "Tensor<bool> should store as uint8_t to avoid vector<bool> quirks");
+    static_assert(std::same_as<typename Tensor<int>::value_type, int>);
+    static_assert(std::same_as<typename Tensor<float>::value_type, float>);
+
+    // Test concept
+    static_assert(pmtv::PmtTensor<Tensor<int>>);
+    static_assert(!pmtv::PmtTensor<std::vector<int>>);
+}
+
+TEST(TensorBasics, DefaultConstruction) {
+    Tensor<int> tensor;
+    EXPECT_EQ(tensor.rank(), 0UZ);
+    EXPECT_EQ(tensor.size(), 0UZ);
+    EXPECT_TRUE(tensor.empty());
+    EXPECT_EQ(tensor.capacity(), 0UZ);
+}
+
+TEST(TensorBasics, ExtentsConstruction) {
+    // Single dimension
+    Tensor<int> vec({5UZ});
+    EXPECT_EQ(vec.rank(), 1UZ);
+    EXPECT_EQ(vec.size(), 5UZ);
+    EXPECT_EQ(vec.extent(0UZ), 5UZ);
+
+    // Multi-dimensional
+    Tensor<int> matrix({3UZ, 4UZ});
+    EXPECT_EQ(matrix.rank(), 2UZ);
+    EXPECT_EQ(matrix.size(), 12UZ);
+    EXPECT_EQ(matrix.extent(0UZ), 3UZ);
+    EXPECT_EQ(matrix.extent(1UZ), 4UZ);
+
+    // 3D tensor
+    Tensor<double> tensor3d({2UZ, 3UZ, 4UZ});
+    EXPECT_EQ(tensor3d.rank(), 3UZ);
+    EXPECT_EQ(tensor3d.size(), 24UZ);
+}
+
+TEST(TensorBasics, CountValueConstruction) {
+    Tensor<double> tensor(5UZ, 42.0);
+    EXPECT_EQ(tensor.rank(), 1UZ);
+    EXPECT_EQ(tensor.size(), 5UZ);
+    EXPECT_TRUE(std::ranges::all_of(tensor, [](double x) { return x == 42.0; }));
+}
+
+TEST(TensorBasics, IteratorConstruction) {
+    std::vector<int> data{10, 20, 30, 40};
+    Tensor<int> tensor(data.begin(), data.end());
+    EXPECT_EQ(tensor.rank(), 1UZ);
+    EXPECT_EQ(tensor.size(), 4UZ);
+    EXPECT_TRUE(std::ranges::equal(tensor, data));
+}
+
+TEST(TensorBasics, ExtentsDataConstruction) {
+    std::vector<int> data{1, 2, 3, 4, 5, 6};
+
+    // Valid construction
+    Tensor<int> tensor({2UZ, 3UZ}, data);
+    EXPECT_EQ(tensor.rank(), 2UZ);
+    EXPECT_EQ(tensor.size(), 6UZ);
+    EXPECT_EQ((tensor[0, 0]), 1);
+    EXPECT_EQ((tensor[1, 2]), 6);
+
+    // Size mismatch should throw
+    EXPECT_THROW((Tensor<int>({2UZ, 2UZ}, data)), std::runtime_error);
+}
+
+// ============================================================================
+// DISAMBIGUATION AND TAGGED CONSTRUCTORS
+// ============================================================================
+
+TEST(TensorDisambiguation, TaggedConstructors) {
+    std::vector<std::size_t> vals{10, 20, 30};
+
+    // extents_from: tensor with shape 10x20x30
+    Tensor<std::size_t> tensor1(pmtv::extents_from, vals);
+    EXPECT_EQ(tensor1.rank(), 3UZ);
+    EXPECT_EQ(tensor1.extent(0), 10UZ);
+    EXPECT_EQ(tensor1.size(), 6000UZ);
+
+    // data_from: 1D tensor with data {10,20,30}
+    Tensor<std::size_t> tensor2(pmtv::data_from, vals);
+    EXPECT_EQ(tensor2.rank(), 1UZ);
+    EXPECT_EQ(tensor2.size(), 3UZ);
+    EXPECT_EQ(tensor2[0], 10UZ);
+    EXPECT_EQ(tensor2[2], 30UZ);
+}
+
+TEST(TensorDisambiguation, NonSizeTTypes) {
+    // For non-size_t types, regular constructors work unambiguously
+    std::vector<int> data{1, 2, 3, 4};
+
+    Tensor<int> tensor1(data);  // This works fine (extents interpretation)
+    EXPECT_EQ(tensor1.rank(), 1UZ);  // Actually creates 1D tensor due to explicit constructor
+
+    Tensor<int> tensor2(pmtv::data_from, data);
+    EXPECT_EQ(tensor2.rank(), 1UZ);
+    EXPECT_TRUE(std::ranges::equal(tensor2, data));
+}
+
+// ============================================================================
+// STD::VECTOR COMPATIBILITY
+// ============================================================================
+
+TEST(TensorVectorCompat, VectorConstruction) {
+    std::vector<int> vec{1, 2, 3, 4, 5};
+
+    // Explicit construction
+    Tensor<int> tensor(vec);
+    EXPECT_EQ(tensor.rank(), 1UZ);
+    EXPECT_EQ(tensor.size(), 5UZ);
+    EXPECT_TRUE(std::ranges::equal(tensor, vec));
+
+    // PMR vector
+    std::pmr::vector<int> pmr_vec{10, 20, 30};
+    Tensor<int> tensor2(pmr_vec);
+    EXPECT_EQ(tensor2.size(), 3UZ);
+    EXPECT_EQ(tensor2[1], 20);
+}
+
+TEST(TensorVectorCompat, VectorAssignment) {
+    std::vector<double> vec{1.5, 2.5, 3.5};
+    Tensor<double> tensor({2, 2});  // Start as 2D
+
+    // Assignment reshapes tensor to match vector
+    tensor = vec;
+    EXPECT_EQ(tensor.rank(), 1UZ);
+    EXPECT_EQ(tensor.size(), 3UZ);
+    EXPECT_TRUE(std::ranges::equal(tensor, vec));
+}
+
+TEST(TensorVectorCompat, VectorConversion) {
+    Tensor<int> tensor({5UZ});
+    std::iota(tensor.begin(), tensor.end(), 1);
+
+    // Convert to std::vector
+    auto vec = static_cast<std::vector<int>>(tensor);
+    EXPECT_TRUE(std::ranges::equal(tensor, vec));
+
+    // Multi-dimensional should throw
+    Tensor<int> matrix({2UZ, 3UZ});
+    EXPECT_THROW(std::ignore = static_cast<std::vector<int>>(matrix), std::runtime_error);
+}
+
+TEST(TensorVectorCompat, CrossTypeComparisons) {
+    std::vector<int> vec{1, 2, 3, 4};
+    Tensor<int> tensor(vec);
+
+    // Symmetric comparison
+    EXPECT_TRUE(tensor == vec);
+    EXPECT_TRUE(vec == tensor);
+
+    // Different sizes
+    std::vector<int> diff_vec{1, 2, 3};
+    EXPECT_FALSE(tensor == diff_vec);
+
+    // Multi-dimensional vs vector
+    Tensor<int> matrix({2UZ, 2UZ});
+    std::iota(matrix.begin(), matrix.end(), 1);
+    EXPECT_FALSE(matrix == vec);  // Different rank
+}
+
+// ============================================================================
+// CTAD (Class Template Argument Deduction)
+// ============================================================================
+
+TEST(TensorCTAD, BasicDeduction) {
+    // From vector
+    std::vector<double> vec{1.0, 2.0, 3.0};
+    Tensor tensor1(vec);
+    static_assert(std::same_as<decltype(tensor1), Tensor<double>>);
+
+    // Count + value
+    Tensor tensor2(5UZ, 42);
+    static_assert(std::same_as<decltype(tensor2), Tensor<int>>);
+
+    // Iterator range
+    Tensor tensor3(vec.begin(), vec.end());
+    static_assert(std::same_as<decltype(tensor3), Tensor<double>>);
+}
+
+TEST(TensorCTAD, TaggedDeduction) {
+    std::vector<float> data{1.0f, 2.0f, 3.0f};
+
+    // Tagged constructors
+    Tensor tensor1(pmtv::data_from, data);
+    static_assert(std::same_as<decltype(tensor1), Tensor<float>>);
+
+    std::vector<std::size_t> extents{3UZ, 4UZ};
+    Tensor tensor2(pmtv::extents_from, extents);
+    static_assert(std::same_as<decltype(tensor2), Tensor<std::size_t>>);
+}
+
+// ============================================================================
+// CORE OPERATIONS (Indexing, Access, Iteration)
+// ============================================================================
+
+TEST(TensorAccess, SingleIndexAccess) {
+    Tensor<int> tensor({5UZ});
+    std::iota(tensor.begin(), tensor.end(), 10);
+
+    // Operator[] (unchecked)
+    EXPECT_EQ(tensor[0], 10);
+    EXPECT_EQ(tensor[4], 14);
+
+    // at() (checked)
+    EXPECT_NO_THROW(std::ignore = tensor.at(0));
+
+    // Front/back
+    EXPECT_EQ(tensor.front(), 10);
+    EXPECT_EQ(tensor.back(), 14);
+}
+
+TEST(TensorAccess, MultiIndexAccess) {
+    Tensor<int> tensor({2UZ, 3UZ});
+
+    // Fill with pattern: tensor[i,j] = 10*i + j
+    for (std::size_t i = 0UZ; i < 2UZ; ++i) {
+        for (std::size_t j = 0UZ; j < 3UZ; ++j) {
+            tensor[i, j] = static_cast<int>(10UZ * i + j);
+        }
+    }
+
+    // Test access
+    EXPECT_EQ((tensor[0UZ, 0UZ]), 0);
+    EXPECT_EQ((tensor[0UZ, 2UZ]), 2);
+    EXPECT_EQ((tensor[1UZ, 0UZ]), 10);
+    EXPECT_EQ((tensor[1UZ, 2UZ]), 12);
+}
+
+TEST(TensorAccess, VariadicAtMethods) {
+    Tensor<int> tensor({3UZ, 4UZ, 2UZ});
+    std::iota(tensor.begin(), tensor.end(), 0);
+
+    // Bounds-checked access
+    EXPECT_EQ(tensor.at(0, 0, 0), 0);
+    EXPECT_EQ(tensor.at(1, 2, 1), (tensor[1, 2, 1]));
+
+    // Out of bounds
+    EXPECT_THROW(std::ignore = tensor.at(3, 0, 0), std::out_of_range);
+    EXPECT_THROW(std::ignore = tensor.at(0, 4, 0), std::out_of_range);
+
+    // Wrong arity
+    EXPECT_THROW(std::ignore = tensor.at(0, 0), std::out_of_range);
+}
+
+TEST(TensorAccess, SpanBasedAccess) {
+    Tensor<int> tensor({2UZ, 3UZ});
+    std::iota(tensor.begin(), tensor.end(), 0);
+
+    // Span-based access
+    std::array<std::size_t, 2UZ> indices{1, 2};
+    EXPECT_EQ(tensor.at(indices), (tensor[1, 2]));
+
+    // Wrong span size
+    std::array<std::size_t, 1> wrong_size{0};
+    EXPECT_THROW(std::ignore = tensor.at(std::span(wrong_size)), std::out_of_range);
+}
+
+TEST(TensorIteration, STLCompatibility) {
+    Tensor<int> tensor({2UZ, 3UZ});
+    std::iota(tensor.begin(), tensor.end(), 1);
+
+    // STL algorithms
+    int sum = std::accumulate(tensor.begin(), tensor.end(), 0);
+    EXPECT_EQ(sum, 21);  // 1+2+3+4+5+6
+
+    // Ranges
+    EXPECT_TRUE(std::ranges::all_of(tensor, [](int x) { return x > 0; }));
+
+    // Row-major order verification
+    std::vector<int> expected{1, 2, 3, 4, 5, 6};
+    EXPECT_TRUE(std::ranges::equal(tensor, expected));
+}
+
+TEST(TensorIteration, DataSpanAccess) {
+    Tensor<int> tensor({2, 3});
+    std::iota(tensor.begin(), tensor.end(), 0);
+
+    // Data span access
+    auto span = tensor.data_span();
+    EXPECT_EQ(span.size(), 6UZ);
+    EXPECT_EQ(span[0], 0);
+    EXPECT_EQ(span[5], 5);
+
+    // Const version
+    const auto& const_tensor = tensor;
+    auto const_span = const_tensor.data_span();
+    EXPECT_EQ(const_span.size(), 6UZ);
+}
+
+// ============================================================================
+// SHAPE OPERATIONS (Reshape, Resize)
+// ============================================================================
+
+TEST(TensorShape, BasicReshape) {
+    Tensor<int> tensor({2UZ, 3UZ});
+    std::iota(tensor.begin(), tensor.end(), 0);
+
+    // Reshape to different layout (same total size)
+    tensor.reshape({3UZ, 2UZ});
+    EXPECT_EQ(tensor.rank(), 2UZ);
+    EXPECT_EQ(tensor.extent(0), 3UZ);
+    EXPECT_EQ(tensor.extent(1), 2UZ);
+    EXPECT_EQ(tensor.size(), 6UZ);
+
+    // Verify row-major interpretation: [0,1,2,3,4,5] -> [[0,1],[2,3],[4,5]]
+    EXPECT_EQ((tensor[0, 0]), 0);
+    EXPECT_EQ((tensor[0, 1]), 1);
+    EXPECT_EQ((tensor[2, 1]), 5);
+}
+
+TEST(TensorShape, ReshapeErrors) {
+    Tensor<int> tensor({2UZ, 3UZ});
+
+    // Size mismatch should throw
+    EXPECT_THROW(tensor.reshape({2UZ, 4UZ}), std::runtime_error);
+    EXPECT_THROW(tensor.reshape({7UZ}), std::runtime_error);
+}
+
+TEST(TensorShape, MultiDimensionalResize) {
+    Tensor<int> tensor;
+
+    // Resize to multi-dimensional
+    tensor.resize({2UZ, 3UZ, 4UZ}, 42);
+    EXPECT_EQ(tensor.rank(), 3UZ);
+    EXPECT_EQ(tensor.size(), 24UZ);
+    EXPECT_EQ((tensor[0, 0, 0]), 42);
+
+    // Change shape entirely
+    tensor.resize({6UZ, 4UZ});
+    EXPECT_EQ(tensor.rank(), 2UZ);
+    EXPECT_EQ(tensor.size(), 24UZ);
+
+    // Clear with empty resize
+    tensor.resize({});
+    EXPECT_TRUE(tensor.empty());
+    EXPECT_EQ(tensor.rank(), 0UZ);
+}
+
+TEST(TensorShape, DimensionSpecificResize) {
+    Tensor<int> tensor({3UZ, 4UZ});
+    std::iota(tensor.begin(), tensor.end(), 0);
+
+    // Resize specific dimension
+    EXPECT_EQ(tensor.extent(1UZ), 4UZ);
+    tensor.resize_dim(1UZ, 6UZ);  // 3x4 -> 3x6
+    EXPECT_EQ(tensor.extent(0UZ), 3UZ);
+    EXPECT_EQ(tensor.extent(1UZ), 6UZ);
+    EXPECT_EQ(tensor.size(), 18UZ);
+
+    // Invalid dimension
+    EXPECT_THROW(tensor.resize_dim(5UZ, 10UZ), std::out_of_range);
+}
+
+TEST(TensorShape, Strides) {
+    Tensor<int> tensor({3UZ, 4UZ, 2UZ});
+    auto strides = tensor.strides();
+
+    EXPECT_EQ(strides.size(), 3UZ);
+    EXPECT_EQ(strides[0], 8UZ);  // 4*2
+    EXPECT_EQ(strides[1], 2UZ);  // 2
+    EXPECT_EQ(strides[2], 1UZ);  // 1
+}
+
+// ============================================================================
+// ASSIGNMENT AND MODIFICATION
+// ============================================================================
+
+TEST(TensorAssignment, RangeAssignment) {
+    Tensor<int> tensor({2UZ, 3UZ});
+
+    // Assignment from std::vector (reshapes)
+    std::vector<int> vec_data{1, 2, 3, 4, 5, 6};
+    tensor = vec_data;
+    EXPECT_EQ(tensor.rank(), 1UZ);
+    EXPECT_TRUE(std::ranges::equal(tensor, vec_data));
+
+    // Assignment from array (preserves shape if size matches)
+    tensor.resize({2UZ, 3UZ});
+    std::array<int, 6> arr_data{10, 11, 12, 13, 14, 15};
+    tensor = arr_data;
+    EXPECT_EQ(tensor.rank(), 2UZ);  // Shape preserved
+    EXPECT_TRUE(std::ranges::equal(tensor, arr_data));
+}
+
+TEST(TensorAssignment, ValueAssignment) {
+    Tensor<int> tensor({2UZ, 3UZ});
+
+    // Fill with single value
+    tensor = 99;
+    EXPECT_TRUE(std::ranges::all_of(tensor, [](int x) { return x == 99; }));
+}
+
+TEST(TensorAssignment, AssignMethod) {
+    Tensor<int> tensor;
+
+    // assign from range
+    std::vector<int> data{1, 2, 3, 4};
+    tensor.assign(data);
+    EXPECT_TRUE(std::ranges::equal(tensor, data));
+
+    // assign count + value
+    tensor.assign(3UZ, 99);
+    EXPECT_EQ(tensor.size(), 3UZ);
+    EXPECT_TRUE(std::ranges::all_of(tensor, [](int x) { return x == 99; }));
+}
+
+TEST(TensorModification, VectorLikeOperations) {
+    Tensor<int> tensor;
+
+    // Build up tensor
+    tensor.push_back(10);
+    tensor.push_back(20);
+    tensor.emplace_back(30);
+
+    EXPECT_EQ(tensor.size(), 3UZ);
+    EXPECT_EQ(tensor.rank(), 1UZ);
+    EXPECT_EQ(tensor.front(), 10);
+    EXPECT_EQ(tensor.back(), 30);
+
+    // Pop elements
+    tensor.pop_back();
+    EXPECT_EQ(tensor.size(), 2UZ);
+    EXPECT_EQ(tensor.back(), 20);
+}
+
+TEST(TensorModification, MultiDimToVectorConversion) {
+    // Multi-dimensional tensor flattens on push
+    Tensor<int> matrix({2UZ, 3UZ});
+    std::iota(matrix.begin(), matrix.end(), 0);
+
+    matrix.push_back(100);
+    EXPECT_EQ(matrix.rank(), 1UZ);
+    EXPECT_EQ(matrix.size(), 7UZ);
+    EXPECT_EQ(matrix.back(), 100);
+}
+
+TEST(TensorModification, Fill) {
+    Tensor<int> tensor({2UZ, 3UZ});
+    tensor.fill(42);
+    EXPECT_TRUE(std::ranges::all_of(tensor, [](int x) { return x == 42; }));
+}
+
+// ============================================================================
+// COMPARISONS
+// ============================================================================
+
+TEST(TensorComparison, EqualityOperator) {
+    Tensor<int> A({2UZ, 2UZ});
+    Tensor<int> B({2UZ, 2UZ});
+    std::iota(A.begin(), A.end(), 0);
+    std::iota(B.begin(), B.end(), 0);
+
+    EXPECT_TRUE(A == B);
+
+    // Different data
+    B[0, 0] = 100;
+    EXPECT_FALSE(A == B);
+
+    // Different shape
+    Tensor<int> C({2UZ, 3UZ});
+    EXPECT_FALSE(A == C);
+}
+
+TEST(TensorComparison, SpaceshipOperator) {
+    Tensor<int> A({2UZ, 2UZ});
+    Tensor<int> B({2UZ, 2UZ});
+    std::iota(A.begin(), A.end(), 0);
+    std::iota(B.begin(), B.end(), 0);
+
+    // Equal tensors
+    EXPECT_EQ(A <=> B, std::strong_ordering::equal);
+
+    // Different shapes (compares extents first)
+    Tensor<int> C({3UZ, 2UZ});
+    EXPECT_NE(A <=> C, std::strong_ordering::equal);
+
+    // Different data
+    B[0, 0] = 100;
+    EXPECT_NE(A <=> B, std::strong_ordering::equal);
+}
+
+// ============================================================================
+// ADVANCED FEATURES (MDspan, PMR, Views)
+// ============================================================================
+
+TEST(TensorAdvanced, PMRSupport) {
+    std::array<std::byte, 4096UZ> buffer;
+    std::pmr::monotonic_buffer_resource arena(buffer.data(), buffer.size());
+
+    Tensor<int> tensor({4UZ, 4UZ}, &arena);
+    std::iota(tensor.begin(), tensor.end(), 0);
+
+    EXPECT_EQ(tensor.size(), 16UZ);
+    EXPECT_EQ((tensor[3, 3]), 15);
+
+    // Verify memory resource is used
+    EXPECT_EQ(tensor._data.get_allocator().resource(), &arena);
+}
+
+TEST(TensorAdvanced, Views) {
+    #if !defined(TENSOR_HAVE_MDSPAN)
+    Tensor<int> tensor({2UZ, 3UZ});
+    std::iota(tensor.begin(), tensor.end(), 0);
+
+    // Non-const view
+    auto view = tensor.view();
+    EXPECT_EQ(view.data(), tensor.data());
+    EXPECT_EQ(view.extents().size(), 2UZ);
+    EXPECT_EQ(view.strides().size(), 2UZ);
+
+    // Const view
+    const auto& const_tensor = tensor;
+    auto const_view = const_tensor.view();
+    EXPECT_EQ(const_view.data(), tensor.data());
+    #endif
+}
+
+#if __has_include(<mdspan>)
+TEST(TensorAdvanced, MdspanIntegration) {
+    Tensor<int> tensor({2, 3});
+    std::iota(tensor.begin(), tensor.end(), 0);
+
+    auto view = tensor.view();
+    EXPECT_EQ(view.extent(0), 2UZ);
+    EXPECT_EQ(view.extent(1), 3UZ);
+
+    // Test access through mdspan
+    EXPECT_EQ(view(1, 2), (tensor[1, 2]));
+}
+#endif
+
+TEST(TensorAdvanced, Swap) {
+    Tensor<int> A({2UZ, 2UZ});
+    Tensor<int> B({3UZ, 3UZ});
+    std::iota(A.begin(), A.end(), 0);
+    std::iota(B.begin(), B.end(), 10);
+
+    auto A_copy = A;
+    auto B_copy = B;
+
+    // Member swap
+    A.swap(B);
+    EXPECT_EQ(A, B_copy);
+    EXPECT_EQ(B, A_copy);
+
+    // Free function swap
+    swap(A, B);
+    EXPECT_EQ(A, A_copy);
+    EXPECT_EQ(B, B_copy);
+}
+
+// ============================================================================
+// EDGE CASES AND ERROR HANDLING
+// ============================================================================
+
+TEST(TensorEdgeCases, EmptyTensor) {
+    Tensor<int> tensor;
+
+    // Operations on empty tensor
+    EXPECT_THROW(std::ignore = tensor.front(), std::runtime_error);
+    EXPECT_THROW(std::ignore = tensor.back(), std::runtime_error);
+    EXPECT_THROW(tensor.pop_back(), std::runtime_error);
+
+    // Should be able to reserve on empty
+    EXPECT_NO_THROW(tensor.reserve(100UZ));
+    EXPECT_GE(tensor.capacity(), 100UZ);
+}
+
+TEST(TensorEdgeCases, SingleElement) {
+    Tensor<int> tensor({1UZ});
+    tensor[0] = 42;
+
+    EXPECT_EQ(tensor.size(), 1UZ);
+    EXPECT_EQ(tensor.front(), 42);
+    EXPECT_EQ(tensor.back(), 42);
+    EXPECT_EQ(tensor[0], 42);
+
+    // Should be able to pop
+    tensor.pop_back();
+    EXPECT_TRUE(tensor.empty());
+}
+
+TEST(TensorEdgeCases, ZeroDimensions) {
+    // Tensor with zero in one dimension
+    Tensor<int> tensor({3UZ, 0UZ, 4UZ});
+    EXPECT_EQ(tensor.size(), 0UZ);
+    EXPECT_EQ(tensor.rank(), 3UZ);
+}
+
+TEST(TensorEdgeCases, BoolTensorBehavior) {
+    // Verify bool -> uint8_t conversion works correctly
+    Tensor<bool> tensor(5UZ, true);
+
+    // Should store as uint8_t internally
+    static_assert(std::same_as<decltype(tensor)::value_type, uint8_t>);
+
+    // But behave like bool
+    EXPECT_TRUE(tensor[0]);
+    tensor[0] = false;
+    EXPECT_FALSE(tensor[0]);
+}
+
+TEST(TensorErrors, OverflowDetection) {
+    // Overflow in extents product
+    const std::size_t big = std::numeric_limits<std::size_t>::max() / 2UZ + 1UZ;
+    EXPECT_THROW((Tensor<int>({big, 3})), std::length_error);
+}
+
+TEST(TensorErrors, BoundsChecking) {
+    Tensor<int> tensor({2UZ, 3UZ});
+
+    // Various bounds violations
+    EXPECT_THROW(std::ignore = tensor.at(2, 0), std::out_of_range);
+    EXPECT_THROW(std::ignore = tensor.at(0, 3), std::out_of_range);
+    EXPECT_THROW(std::ignore = tensor.at(0, 0, 0), std::out_of_range);  // Wrong arity
+
+    // Span-based bounds checking
+    std::array<std::size_t, 2UZ> bad_idx{2UZ, 0UZ};
+    EXPECT_THROW(std::ignore = tensor.at(std::span(bad_idx)), std::out_of_range);
+}
+
+// ============================================================================
+// PART 11: MEMORY MANAGEMENT AND PERFORMANCE
+// ============================================================================
+
+TEST(TensorMemory, CapacityManagement) {
+    Tensor<int> tensor;
+
+    // Reserve capacity
+    tensor.reserve(1000UZ);
+    EXPECT_GE(tensor.capacity(), 1000UZ);
+
+    // Add elements without reallocation
+    for (int i = 0; i < 500; ++i) {
+        tensor.push_back(i);
+    }
+    EXPECT_EQ(tensor.size(), 500UZ);
+    EXPECT_GE(tensor.capacity(), 1000UZ);
+
+    // Shrink
+    tensor.shrink_to_fit();
+    // Note: shrink_to_fit is not guaranteed to reduce capacity
+}
+
+TEST(TensorMemory, MoveSemantics) {
+    Tensor<int> source({100UZ});
+    std::iota(source.begin(), source.end(), 0);
+    auto original = std::vector<int>(source.begin(), source.end());
+
+    // Move construction
+    Tensor<int> moved(std::move(source));
+    EXPECT_TRUE(std::ranges::equal(moved, original));
+
+    // Move assignment
+    Tensor<int> target;
+    target = std::move(moved);
+    EXPECT_TRUE(std::ranges::equal(target, original));
+}
+
+// ============================================================================
+// PART 12: STRESS TESTS
+// ============================================================================
+
+TEST(TensorStress, LargeOperations) {
+    Tensor<int> tensor({1000UZ, 1000UZ});
+    EXPECT_EQ(tensor.size(), 1000000UZ);
+
+    // Multiple reshapes
+    tensor.reshape({2000UZ, 500UZ});
+    EXPECT_EQ(tensor.size(), 1000000UZ);
+
+    tensor.reshape({100UZ, 100UZ, 100UZ});
+    EXPECT_EQ(tensor.size(), 1000000UZ);
+
+    tensor.reshape({1000000UZ});
+    EXPECT_EQ(tensor.rank(), 1UZ);
+}
+
+TEST(TensorStress, ManyOperations) {
+    Tensor<int> tensor;
+
+    // Many push operations
+    for (int i = 0; i < 10000; ++i) {
+        tensor.push_back(i);
+    }
+    EXPECT_EQ(tensor.size(), 10000UZ);
+
+    // verify data integrity
+    for (int i = 0; i < 10000; ++i) {
+        EXPECT_EQ(tensor[i], i);
+    }
+
+    // many pop operations
+    for (int i = 0; i < 5000; ++i) {
+        tensor.pop_back();
+    }
+    EXPECT_EQ(tensor.size(), 5000UZ);
+}

--- a/test/qa_uniform_vector.cpp
+++ b/test/qa_uniform_vector.cpp
@@ -38,42 +38,42 @@ public:
     T get_value(int i) { return T(i); }
     T zero_value() { return T(0); }
     T nonzero_value() { return T(17); }
-    static const std::size_t num_values_ = 10;
+    static constexpr std::size_t num_values_ = 10UZ;
 };
 
 
 template <>
 std::complex<float> PmtVectorFixture<std::complex<float>>::get_value(int i)
 {
-    return std::complex<float>(static_cast<float>(i), static_cast<float>(-i));
+    return { static_cast<float>(i), static_cast<float>(-i) };
 }
 
 template <>
 std::complex<double> PmtVectorFixture<std::complex<double>>::get_value(int i)
 {
-    return std::complex<double>(static_cast<double>(i), static_cast<double>(-i));
+    return { static_cast<double>(i), static_cast<double>(-i) };
 }
 
 template <>
 std::complex<float> PmtVectorFixture<std::complex<float>>::zero_value()
 {
-    return std::complex<float>(0, 0);
+    return { 0, 0};
 }
 template <>
 std::complex<double> PmtVectorFixture<std::complex<double>>::zero_value()
 {
-    return std::complex<double>(0, 0);
+    return {0, 0};
 }
 
 template <>
 std::complex<float> PmtVectorFixture<std::complex<float>>::nonzero_value()
 {
-    return std::complex<float>(17, -19);
+    return { 17, -19};
 }
 template <>
 std::complex<double> PmtVectorFixture<std::complex<double>>::nonzero_value()
 {
-    return std::complex<double>(17, -19);
+    return {17, -19 };
 }
 
 TYPED_TEST_SUITE(PmtVectorFixture, testing_types);
@@ -92,12 +92,12 @@ TYPED_TEST(PmtVectorFixture, VectorConstructors)
     pmt empty_vec{ pmtv::Tensor<TypeParam>() };
     EXPECT_EQ(std::get<pmtv::Tensor<TypeParam>>(empty_vec).size(), 0);    
 
-    std::vector<size_t> v(1, this->num_values_);
+    std::vector<size_t> v(1UZ, this->num_values_);
     std::cout << v[0] << std::endl;
-    pmt sized_vec(pmtv::tensor_t<TypeParam>, v);
+    pmt sized_vec(pmtv::tensor_t<TypeParam>, pmtv::extents_from, v);
     EXPECT_EQ(std::get<Tensor<TypeParam>>(sized_vec).size(), v[0]);
 
-    pmtv::Tensor<TypeParam> vec(Tensor1d(), this->num_values_);
+    pmtv::Tensor<TypeParam> vec({this->num_values_});
     for (std::size_t i = 0; i < this->num_values_; i++) {
         vec[i] = this->get_value(static_cast<int>(i));
     }
@@ -127,7 +127,7 @@ TYPED_TEST(PmtVectorFixture, VectorConstructors)
 TYPED_TEST(PmtVectorFixture, PmtVectorSerialize)
 {
     // Serialize/Deserialize and make sure that it works
-    pmtv::Tensor<TypeParam> vec(Tensor1d(), this->num_values_);
+    pmtv::Tensor<TypeParam> vec({this->num_values_});
     for (std::size_t i = 0; i < this->num_values_; i++) {
         vec[i] = this->get_value(static_cast<int>(i));
     }
@@ -141,8 +141,8 @@ TYPED_TEST(PmtVectorFixture, PmtVectorSerialize)
 TYPED_TEST(PmtVectorFixture, VectorWrites)
 {
     // Initialize a PMT Wrap from a std::vector object
-    pmtv::Tensor<TypeParam> vec(Tensor1d(), this->num_values_);
-    pmtv::Tensor<TypeParam> vec_modified(Tensor1d(), this->num_values_);
+    pmtv::Tensor<TypeParam> vec({this->num_values_});
+    pmtv::Tensor<TypeParam> vec_modified({this->num_values_});
     for (std::size_t i = 0; i < this->num_values_; i++) {
         vec[i] = this->get_value(static_cast<int>(i));
         vec_modified[i] = vec[i];
@@ -164,7 +164,7 @@ TYPED_TEST(PmtVectorFixture, VectorWrites)
 
 TYPED_TEST(PmtVectorFixture, get_as)
 {
-    pmtv::Tensor<TypeParam> vec(Tensor1d(), this->num_values_);
+    pmtv::Tensor<TypeParam> vec({this->num_values_});
     for (std::size_t i = 0; i < this->num_values_; i++) {
         vec[i] = this->get_value(static_cast<int>(i));
     }
@@ -180,7 +180,7 @@ TYPED_TEST(PmtVectorFixture, get_as)
 
 TYPED_TEST(PmtVectorFixture, base64)
 {
-    Tensor<TypeParam> vec(Tensor1d(), this->num_values_);
+    Tensor<TypeParam> vec({ this->num_values_ });
     pmt x = vec;
 
     // Make sure that we can get the value back out
@@ -191,7 +191,7 @@ TYPED_TEST(PmtVectorFixture, base64)
 }
 
 TYPED_TEST(PmtVectorFixture, fmt) {
-    Tensor<TypeParam> vec(Tensor1d(), this->num_values_);
+    Tensor<TypeParam> vec({ this->num_values_ });
     pmt x = vec;
     EXPECT_EQ(fmt::format("{}", x), fmt::format("[{}]", fmt::join(vec.data_span(), ", ")));
 }

--- a/test/qa_vector_of_pmts.cpp
+++ b/test/qa_vector_of_pmts.cpp
@@ -42,8 +42,8 @@ TEST(PmtVectorPmt, Constructor) {
     EXPECT_EQ(std::get<std::vector<pmt>>(empty_vec).size(), 0);
     pmt il_vec{std::vector<pmt>{1.0, 2, "abc"}};
     std::vector<pmt> vec;
-    vec.push_back(pmt(1));
-    vec.push_back(pmt(Tensor<uint32_t>(Tensor1d(), { 1, 2, 3 })));    
+    vec.emplace_back(1);
+    vec.emplace_back(Tensor<uint32_t>(pmtv::data_from, std::vector<uint32_t>{ 1, 2, 3 }));
 
     auto p = pmt(vec);
 
@@ -55,8 +55,8 @@ TEST(PmtVectorPmt, Constructor) {
 
 TEST(PmtVectorPmt, fmt) {
     std::vector<pmt> vec;
-    vec.push_back(pmt(1));
-    vec.push_back(pmt(Tensor<uint32_t>(Tensor1d(), { 1, 2, 3 })));    
+    vec.emplace_back(1);
+    vec.emplace_back(Tensor<uint32_t>(pmtv::data_from, std::vector<uint32_t>{ 1, 2, 3 }));
     EXPECT_EQ(fmt::format("{}", pmt(vec)), fmt::format("[{}]", fmt::join(vec, ", ")));
 
 }


### PR DESCRIPTION
@jsallay thanks for preparing the `Tensor<T>` support in pmt. Here are some thoughts/suggestions that you may mix and match as you see fit.

 * switch to C++23 (README, meson cpp_std=c++23; default werror=false).

 * Tensor<T> expansion:
   * PMR-backed storage for extents and data; optional MR in ctors/ops.
   * disambiguation for std::size_t ranges via tags: extents_from / data_from.
   * ctors: extents+data ranges, init-lists, count+value, iterator pairs, std::vector/std::pmr::vector; CTAD guides.
   * safe size computation with overflow detection; zero-extent dims → total size 0.
   * row-major indexing helpers: unchecked operator[](...) (variadic), checked at(...) (variadic/span), index_of(...), bounds_check(...).
  * std::vector-like API: capacity/reserve/shrink_to_fit/clear/push_back/emplace_back/pop_back/front/back/assign/fill/swap.
  * conversions and comparisons with std::vector/std::pmr::vector; <=> implemented.
  * shape ops: resize(...), resize_dim(dim, n), reshape(...); strides() (row-major).
  * std::mdspan if available (TENSOR_HAVE_MDSPAN), otherwise a lightweight view (data/extents/strides).
  * minor code/warning clean-ups

 Note:
  * drops Tensor1d tag; use data_from for 1-D construction (or pass a vector), and extents_from to force shape.
  * push_back on multi-dim tensors flattens to 1-D by design.